### PR TITLE
Make the progressbar Valign be GTK_ALIGN_END instead of .._FILL.

### DIFF
--- a/gtk/src/widgets/upgrade_option.rs
+++ b/gtk/src/widgets/upgrade_option.rs
@@ -42,6 +42,7 @@ impl UpgradeOption {
             gtk::ProgressBar::new();
             ..set_ellipsize(pango::EllipsizeMode::End);
             ..set_hexpand(true);
+            ..set_valign(gtk::Align::End);
         };
 
         let stack = cascade! {


### PR DESCRIPTION
Prevents the bar from getting T H I C C C when there isn't a
widget above it.