### PR TITLE
Upgrade GTK Widget (continued)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,6 +2028,7 @@ version = "0.1.0"
 dependencies = [
  "apt-cli-wrappers 0.1.0 (git+https://github.com/pop-os/apt-cli-wrappers)",
  "cascade 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "gio 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 apt-cli-wrappers = { git = "https://github.com/pop-os/apt-cli-wrappers" }
 cascade = "0.1.3"
+clap = "2.33.0"
 err-derive = "0.1.5"
 gio = "0.7.0"
 glib = "0.8.1"

--- a/gtk/src/errors.rs
+++ b/gtk/src/errors.rs
@@ -3,8 +3,12 @@ use std::error::Error as ErrorTrait;
 
 #[derive(Debug, Error)]
 pub enum UiError {
+    #[error(display = "failed to cancel upgrade")]
+    Cancel(#[error(cause)] ClientError),
     #[error(display = "failed to dismiss notifications")]
     Dismiss(#[error(cause)] UnderlyingError),
+    #[error(display = "failed to finalize release upgrade")]
+    Finalize(#[error(cause)] ClientError),
     #[error(display = "recovery upgrade failed")]
     Recovery(#[error(cause)] UnderlyingError),
     #[error(display = "failed to set up OS refresh")]

--- a/gtk/src/events.rs
+++ b/gtk/src/events.rs
@@ -10,6 +10,7 @@ use std::sync::mpsc::SyncSender;
 #[derive(Debug)]
 pub enum BackgroundEvent {
     DownloadUpgrade(ReleaseInfo),
+    Finalize,
     GetStatus(DaemonStatus),
     IsActive(SyncSender<bool>),
     DismissNotification,

--- a/gtk/src/events.rs
+++ b/gtk/src/events.rs
@@ -23,6 +23,7 @@ pub enum BackgroundEvent {
 /// Events received for the UI to handle.
 #[derive(Debug)]
 pub enum UiEvent {
+    CancelledUpgrade,
     Completed(CompletedEvent),
     Dismissed,
     Error(UiError),

--- a/gtk/src/lib.rs
+++ b/gtk/src/lib.rs
@@ -221,6 +221,10 @@ impl UpgradeWidget {
                         fetching_release = true;
                     }
                     UiEvent::CancelledUpgrade => {
+                        if let Some(cb) = callback_event.upgrade() {
+                            cb.borrow()(Event::NotUpgrading);
+                        }
+
                         upgrade_downloaded = false;
                         option_upgrade
                             .set_label(&*upgrade_label)
@@ -402,11 +406,6 @@ impl UpgradeWidget {
                             reboot()
                         } else {
                             option_upgrade.set_label("Canceling upgrade");
-
-                            if let Some(cb) = callback_event.upgrade() {
-                                cb.borrow()(Event::NotUpgrading);
-                            }
-
                             let _ = sender.send(BackgroundEvent::Reset);
                             return gtk::Continue(true);
                         }

--- a/gtk/src/lib.rs
+++ b/gtk/src/lib.rs
@@ -405,6 +405,10 @@ impl UpgradeWidget {
                         if gtk::ResponseType::Accept == answer {
                             reboot()
                         } else {
+                            // Send upgrading event to prevent closing
+                            if let Some(cb) = callback_event.upgrade() {
+                                cb.borrow()(Event::Upgrading);
+                            }
                             option_upgrade.set_label("Canceling upgrade");
                             let _ = sender.send(BackgroundEvent::Reset);
                             return gtk::Continue(true);

--- a/gtk/src/lib.rs
+++ b/gtk/src/lib.rs
@@ -735,7 +735,7 @@ fn scan(client: &Client, send: &dyn Fn(UiEvent)) {
 
     let reboot_ready = Path::new(STARTUP_UPGRADE_FILE).exists();
 
-    let upgrade_text = if release::upgrade_in_progress() {
+    let upgrade_text = if !reboot_ready && release::upgrade_in_progress() {
         Cow::Borrowed("Pop!_OS is currently downloading.")
     } else {
         let devel = pop_upgrade::development_releases_enabled();

--- a/gtk/src/main.rs
+++ b/gtk/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
     glib::set_program_name(APP_ID.into());
 
     let application =
-        Application::new(APP_ID, ApplicationFlags::empty()).expect("GTK initialization failed");
+        Application::new(Some(APP_ID), ApplicationFlags::empty()).expect("GTK initialization failed");
 
     application.connect_activate(|app| {
         if let Some(window) = app.get_window_by_id(0) {
@@ -25,7 +25,7 @@ fn main() {
 
         let headerbar = cascade! {
             gtk::HeaderBar::new();
-            ..set_title("Pop! Upgrade Manager");
+            ..set_title(Some("Pop! Upgrade Manager"));
             ..set_show_close_button(true);
             ..show();
         };
@@ -33,7 +33,7 @@ fn main() {
         let _window = cascade! {
             gtk::ApplicationWindow::new(app);
             ..set_titlebar(Some(&headerbar));
-            ..set_icon_name("firmware-manager");
+            ..set_icon_name(Some("firmware-manager"));
             ..set_keep_above(true);
             ..set_property_window_position(gtk::WindowPosition::Center);
             ..add(cascade! {

--- a/gtk/src/main.rs
+++ b/gtk/src/main.rs
@@ -10,8 +10,8 @@ pub const APP_ID: &str = "com.system76.UpgradeManager";
 fn main() {
     glib::set_program_name(APP_ID.into());
 
-    let application =
-        Application::new(Some(APP_ID), ApplicationFlags::empty()).expect("GTK initialization failed");
+    let application = Application::new(Some(APP_ID), ApplicationFlags::empty())
+        .expect("GTK initialization failed");
 
     application.connect_activate(|app| {
         if let Some(window) = app.get_window_by_id(0) {

--- a/gtk/src/widgets/dialogs/upgrade.rs
+++ b/gtk/src/widgets/dialogs/upgrade.rs
@@ -44,7 +44,7 @@ impl UpgradeDialog {
             "distributor-logo",
             "Upgrade",
             "Reboot & Upgrade",
-            &gtk::STYLE_CLASS_SUGGESTED_ACTION,
+            &gtk::STYLE_CLASS_DESTRUCTIVE_ACTION,
             |content| {
                 content.add(&title);
                 content.add(&scroller);

--- a/gtk/src/widgets/upgrade_option.rs
+++ b/gtk/src/widgets/upgrade_option.rs
@@ -78,6 +78,7 @@ impl UpgradeOption {
     }
 
     pub fn button_view(&self) -> &Self {
+        self.progress.hide();
         self.stack.set_visible_child(&self.button);
         self
     }
@@ -95,6 +96,12 @@ impl UpgradeOption {
 
     pub fn progress_exact(&self, percent: u8) -> &Self {
         self.progress.set_fraction(percent as f64 / 100f64);
+        self.progress_view()
+    }
+
+    pub fn progress_view(&self) -> &Self {
+        self.button.hide();
+        self.stack.set_visible_child(&self.progress);
         self
     }
 
@@ -135,11 +142,6 @@ impl UpgradeOption {
             None => self.button.set_visible(false),
         }
 
-        self
-    }
-
-    fn progress_view(&self) -> &Self {
-        self.stack.set_visible_child(&self.progress);
-        self
+        self.button_view()
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -157,6 +157,9 @@ impl Client {
                         self.release_upgrade(method, current.as_ref(), next.as_ref())?;
                         recall = self.event_listen_release_upgrade()?;
                     }
+
+                    // Finalize the release upgrade.
+                    self.release_upgrade_finalize()?;
                 } else {
                     println!("no release available to upgrade to");
                 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -261,6 +261,11 @@ impl Client {
         Ok(())
     }
 
+    pub fn release_upgrade_finalize(&self) -> Result<(), Error> {
+        self.call_method(methods::RELEASE_UPGRADE_FINALIZE, |m| m)?;
+        Ok(())
+    }
+
     /// Retrieves the last known status of a release upgrade.
     pub fn release_upgrade_status(&self) -> Result<Status, Error> {
         self.call_method(methods::RELEASE_UPGRADE_STATUS, |m| m)?

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -13,7 +13,7 @@ use dbus::{
 
 use std::collections::HashMap;
 
-const TIMEOUT: i32 = 3000;
+const TIMEOUT: i32 = -1;
 
 // Information about the current fetch progress.
 #[derive(Clone, Debug)]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -13,7 +13,7 @@ use dbus::{
 
 use std::collections::HashMap;
 
-const TIMEOUT: i32 = -1;
+const TIMEOUT: i32 = 0x7fffffff;
 
 // Information about the current fetch progress.
 #[derive(Clone, Debug)]

--- a/src/daemon/methods.rs
+++ b/src/daemon/methods.rs
@@ -236,6 +236,20 @@ pub fn release_upgrade(
     method.inarg::<u8>("how").inarg::<&str>("from").inarg::<&str>("to").consume()
 }
 
+pub const RELEASE_UPGRADE_FINALIZE: &str = "ReleaseUpgradeFinalize";
+
+pub fn release_upgrade_finalize(
+    daemon: Rc<RefCell<Daemon>>,
+    dbus_factory: &DbusFactory,
+) -> Method<MTFn<()>, ()> {
+    let method = dbus_factory.method::<_, String>(RELEASE_UPGRADE_FINALIZE, move |_| {
+        daemon.borrow_mut().release_upgrade_finalize()?;
+        Ok(Vec::new())
+    });
+
+    method.inarg::<u8>("how").inarg::<&str>("from").inarg::<&str>("to").consume()
+}
+
 pub const RELEASE_UPGRADE_STATUS: &str = "ReleaseUpgradeStatus";
 
 pub fn release_upgrade_status(

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -369,6 +369,7 @@ impl Daemon {
             .add_m(methods::release_upgrade_status(daemon.clone(), &dbus_factory))
             .add_m(methods::release_upgrade(daemon.clone(), &dbus_factory))
             .add_m(methods::repo_modify(daemon.clone(), &dbus_factory))
+            .add_m(methods::reset(daemon.clone(), &dbus_factory))
             .add_m(methods::status(daemon.clone(), &dbus_factory))
             .add_s(fetch_result.clone())
             .add_s(fetched_package.clone())


### PR DESCRIPTION
Includes the last remaining changes before we release the integration of the GTK widget in GNOME Control Center. The previous PR had to be merged so that our CI would build GCC with the new C headers.