### PR TITLE
fix(daemon): Revert source list on any error after updating source lists

### DIFF
--- a/src/release/mod.rs
+++ b/src/release/mod.rs
@@ -457,30 +457,39 @@ impl<'a> DaemonRuntime<'a> {
         next: &str,
     ) -> RelResult<Upgrader<'b>> {
         (*logger)(UpgradeEvent::UpdatingSourceLists);
+        // Updates the source lists, with a handle for reverting the change.
         let mut upgrader = self.release_upgrade(retain, &current, &next)?;
 
-        info!("updated the package lists for the new relaese");
-        apt_update(|ready| {
-            (*logger)(if ready {
-                UpgradeEvent::UpdatingPackageLists
-            } else {
-                UpgradeEvent::AptFilesLocked
+        // Use a closure to capture any early returns due to an error.
+        let updated_list_ops = || {
+            info!("updated the package lists for the new relaese");
+            apt_update(|ready| {
+                (*logger)(if ready {
+                    UpgradeEvent::UpdatingPackageLists
+                } else {
+                    UpgradeEvent::AptFilesLocked
+                })
             })
-        })
-        .map_err(ReleaseError::ReleaseUpdate)?;
+            .map_err(ReleaseError::ReleaseUpdate)?;
 
-        snapd::hold_transitional_packages()?;
+            snapd::hold_transitional_packages()?;
 
-        match self.attempt_fetch(logger, fetch) {
-            Ok(_) => info!("packages fetched successfully"),
+            self.attempt_fetch(logger, fetch)?;
+
+            info!("packages fetched successfully");
+
+            Ok(())
+        };
+
+        // On any error, roll back the source lists.
+        match updated_list_ops() {
+            Ok(_) => Ok(upgrader),
             Err(why) => {
                 rollback(&mut upgrader, &why);
 
                 return Err(why);
             }
         }
-
-        Ok(upgrader)
     }
 }
 


### PR DESCRIPTION
An error in the snapd function caused the source list to remain updated to the new release, later causing a live upgrade to be performed.

This change will wrap all code after the source list changes which may error into a closure. Any error returned from this closure will cause the rollback function to be called to revert the changes.