### PR TITLE
Add changelogs for 19.04 and 18.10

### DIFF
--- a/changelogs/18.10
+++ b/changelogs/18.10
@@ -1,0 +1,17 @@
+* Pop!_OS Shop Application previews now load faster.
+
+* Improvements to the Pop!_Shop UI to prevent it from freezing.
+
+* Resolved many outstanding memory leaks in Pop!_Shop.
+
+* CUDA, TensorFlow, and cuDNN can now all be installed with one command.
+
+* Numerous bug fixes applied to distinst and the installer.
+
+* Distinst has been modularized into numerous Rust crates. 
+
+* Improved Sysem76 Power CLI utility with new subcommands and arguments.
+
+* A new “–experimental” flag was added to the System76 Power daemon to enable additional power-saving features.
+
+* Pop!_OS now hosts its own repos built from our new open source tool.

--- a/changelogs/19.04
+++ b/changelogs/19.04
@@ -1,0 +1,7 @@
+* The Slim Mode option maximizes screen real estate by reducing the height of the header on application windows. 
+
+* Dark Mode gives applications a relaxing ambience for nighttime viewing. Both Dark Mode and Slim Mode can be activated in the Appearance settings menu.
+
+* Refresh Install enables the ability to reinstall Pop!_OS without losing Users and any data in Home directories. This feature is available from the recovery partition on new installations (not upgrades).
+
+* The icons for Pop!_OS applications, files, and folders have been redesigned to complement GNOME’s icons under their new design guidelines.

--- a/changelogs/19.10
+++ b/changelogs/19.10
@@ -2,7 +2,7 @@
 
 * The functionality of Dark Mode has been expanded to include the shell, providing a more consistently dark aesthetic across your desktop. If you’re using the User Themes extension to set the shell theme, disable it to use the new integrated Light and Dark mode switcher.
 
-* The default theme on Pop!_OS has been rebuilt based on Adwaita. Though users may only notice a slight difference in their widgets, the new OS theme provides significant measures to prevent application themes from experiencing UI breakage. This breakage manifests in the application as missing or misaligned text, broken widgets, and scaling errors, and should not occur with the new theme in place.
+* The default theme on Pop!_OS has been rebuilt based on Adwaita. Though users may only notice a slight difference in their widgets, the new OS theme provides significant measures to prevent application themes from experiencing UI breakage. This breakage manifests in the application as missing or misaligned text, broken widgets, and scaling errors, and should not occur with the new theme in place. Slim mode has been removed as part of this change, as it could cause breakages with apps due to padding changes.
 
 * The updated theme includes a new set of modernized sound effects. Users will now hear a sound effect when plugging and unplugging a USB or charging cable. The sound effect for adjusting the volume has been removed.
 

--- a/src/changelogs.rs
+++ b/src/changelogs.rs
@@ -1,6 +1,10 @@
 use std::cmp::Ordering;
 
-pub const CHANGELOGS: &[(&str, &str)] = &[("19.10", include_str!("../changelogs/19.10"))];
+pub const CHANGELOGS: &[(&str, &str)] = &[
+    ("19.10", include_str!("../changelogs/19.10")),
+    ("19.04", include_str!("../changelogs/19.04")),
+    ("18.10", include_str!("../changelogs/18.10")),
+];
 
 pub fn since<'a>(release: &'a str) -> impl Iterator<Item = (&'static str, &'static str)> + 'a {
     CHANGELOGS


### PR DESCRIPTION
I created changelogs based on the content provided in System76 blog posts from release.

https://blog.system76.com/post/184281497363/popos-1904-is-here

https://blog.system76.com/post/179217201328/see-what-changes-have-been-orbiting-popos

This pr resolves https://github.com/pop-os/upgrade/issues/55