### PR TITLE
feat(cli) upgrade: output current, next, available

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -138,6 +138,21 @@ impl Client {
                     matches.is_present("force-next") || pop_upgrade::development_releases_enabled();
                 let (current, next, available, _is_lts) = self.release_check(forcing)?;
 
+                if atty::is(atty::Stream::Stdout) {
+                    let mut buffer = String::new();
+                    println!(
+                        "{}: {}",
+                        color_primary("Current Release"),
+                        color_secondary(&current)
+                    );
+                    println!("{}: {}", color_primary("Upgrading to"), color_secondary(&next));
+                    println!(
+                        "{}: {}",
+                        color_primary("New version available"),
+                        color_secondary(misc::format_build_number(available, &mut buffer))
+                    );
+                }
+
                 // Only upgrade if an upgrade is possible, or if being forced to upgrade.
                 if forcing || available >= 0 {
                     // Before doing a release upgrade with the recovery partition, ensure that

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -140,16 +140,10 @@ impl Client {
 
                 if atty::is(atty::Stream::Stdout) {
                     let mut buffer = String::new();
-                    println!(
-                        "{}: {}",
-                        color_primary("Current Release"),
-                        color_secondary(&current)
-                    );
-                    println!("{}: {}", color_primary("Upgrading to"), color_secondary(&next));
-                    println!(
-                        "{}: {}",
-                        color_primary("New version available"),
-                        color_secondary(misc::format_build_number(available, &mut buffer))
+                    pintln!(
+                        (color_primary("Current Release")) ": " (color_secondary(&current)) "\n"
+                        (color_primary("Upgrading to")) ": " (color_secondary(&next)) "\n"
+                        (color_primary("New version available")) ": " (color_secondary(misc::format_build_number(available, &mut buffer)))
                     );
                 }
 


### PR DESCRIPTION
Addresses a usability issue discussed further in #98 and #99 by outputting current, next, and available to STDOUT on every invocation of `upgrade`.

![image](https://user-images.githubusercontent.com/1284973/80290006-9d822500-8710-11ea-8346-91892249bc20.png)

Closes #98