### PR TITLE
changes relaese to release

### DIFF
--- a/src/release/mod.rs
+++ b/src/release/mod.rs
@@ -472,7 +472,7 @@ impl DaemonRuntime {
 
         // Use a closure to capture any early returns due to an error.
         let updated_list_ops = || {
-            info!("updated the package lists for the new relaese");
+            info!("updated the package lists for the new release");
             apt_update(|ready| {
                 (*logger)(if ready {
                     UpgradeEvent::UpdatingPackageLists


### PR DESCRIPTION
This is just a simple typo fix that I found in someone's logs:

Jul 22 12:02:11 pop-os pop-upgrade[25184]: [INFO ] pop_upgrade src/release/mod.rs:475: updated the package lists for the new relaese