### PR TITLE
fix: Add .shlibs file, and update version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pop-upgrade"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Michael Aaron Murphy <mmstickman@gmail.com>"]
 license = "GPL-3.0"
 edition = "2018"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-upgrade (0.1.1) groovy; urgency=medium
+
+  * Include SONAME in library
+
+ -- Ian Douglas Scott <idscott@system76.com>  Tue, 01 Dec 2020 09:03:15 -0800
+
 pop-upgrade (0.1.0) cosmic; urgency=medium
 
   * Initial release.

--- a/debian/libpop-upgrade-gtk.shlibs
+++ b/debian/libpop-upgrade-gtk.shlibs
@@ -1,0 +1,1 @@
+libpop_upgrade_gtk 0 libpop-upgrade-gtk (>= 0.1.0)

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pop-upgrade-gtk"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Michael Aaron Murphy <mmstick@pm.me>"]
 edition = "2018"
 

--- a/gtk/ffi/Cargo.toml
+++ b/gtk/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pop-upgrade-gtk-ffi"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Michael Aaron Murphy <mmstick@pm.me>"]
 edition = "2018"
 


### PR DESCRIPTION
It seems the gnome-control-center binary ends up linking against the SONAME symlink, so it should depend on a version that includes it. With this, `dh_shlibdeps` generates such a dependency. This, or `.symbols`, is also required by the debian policy manual, so it's probably best to tend to follow the conventions for `.deb` packages.

This should not change the behavior of anything other than new packages built against this library.

Building the 3.38.2 branch of gnome-control-center with `fakeroot make -f debian/rules binary` when this version is installed resulted in a generated dependency with the version requirement from `.shlibs`.