### PR TITLE
Enable development upgrades to 21.04

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "pop-upgrade"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "apt-cmd",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "pop-upgrade-gtk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "apt-cmd",
  "better-panic",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "pop-upgrade-gtk-ffi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cdylib-link-lines",
  "glib",

--- a/src/release/check.rs
+++ b/src/release/check.rs
@@ -97,7 +97,7 @@ pub fn release_str(major: u8, minor: u8) -> &'static str {
 
 fn next_(
     current: Version,
-    _development: bool,
+    development: bool,
     release_check: impl Fn(&str) -> BuildStatus,
 ) -> ReleaseStatus {
     let next: &str;
@@ -121,11 +121,15 @@ fn next_(
             ReleaseStatus { build: release_check(next), current: "20.04", is_lts: true, next }
         }
 
-        (20, 10) => ReleaseStatus {
-            build:   BuildStatus::Blacklisted,
-            current: "20.10",
-            is_lts:  false,
-            next:    "21.04",
+        (20, 10) => {
+            next = "21.04";
+
+            ReleaseStatus {
+                build:   if development { release_check(next) } else { BuildStatus::Blacklisted },
+                current: "20.10",
+                is_lts:  false,
+                next,
+            }
         },
 
         (21, 4) => ReleaseStatus {


### PR DESCRIPTION
This _should_ allow upgrades to 21.04 using the --force-next flag. I have not tested it yet, will do so after it builds