### PR TITLE
fix(ffi): Initialize fluent locale on widget create

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,8 @@ dependencies = [
  "glib",
  "gtk",
  "gtk-sys",
+ "i18n-embed",
+ "i18n-embed-fl",
  "pop-upgrade-gtk",
 ]
 

--- a/gtk/ffi/Cargo.toml
+++ b/gtk/ffi/Cargo.toml
@@ -12,6 +12,8 @@ pop-upgrade-gtk = { path = "../" }
 glib = "0.10"
 gtk-sys = "0.10"
 gtk = { version = "0.9", features = [ "v3_22" ] }
+i18n-embed = { version = "0.12.0", features = ["fluent-system", "desktop-requester"] }
+i18n-embed-fl = "0.5.0"
 
 [lib]
 name = "pop_upgrade_gtk"

--- a/gtk/ffi/src/lib.rs
+++ b/gtk/ffi/src/lib.rs
@@ -1,5 +1,6 @@
 use glib::object::ObjectType;
 use pop_upgrade_gtk::*;
+use i18n_embed::DesktopLanguageRequester;
 use std::{ffi, ptr};
 
 #[no_mangle]
@@ -17,6 +18,13 @@ pub extern "C" fn pop_upgrade_widget_new() -> *mut PopUpgradeWidget {
     // When used from C, assume that GTK has been initialized.
     unsafe {
         gtk::set_initialized();
+    }
+
+    let localizer = localizer();
+    let requested_languages = DesktopLanguageRequester::requested_languages();
+
+    if let Err(error) = localizer.select(&requested_languages) {
+        eprintln!("Error while loading languages for pop_upgrade_gtk {}", error);
     }
 
     Box::into_raw(Box::new(UpgradeWidget::new())) as *mut _


### PR DESCRIPTION
This will fix the locale defaulting to `en` in the widget from C.