### PR TITLE
feat: Add cosmic favorites on upgrade

### DIFF
--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -1,0 +1,66 @@
+use as_result::MapResult;
+use std::{
+    process::Command,
+    str,
+};
+
+const SETTINGS_JS_SCRIPT: &str = "
+const Gio = imports.gi.Gio;
+
+const COSMIC_FAVORITES = [
+    'pop-cosmic-launcher.desktop',
+    'pop-cosmic-workspaces.desktop',
+    'pop-cosmic-applications.desktop',
+];
+
+const settings = new Gio.Settings({schema_id: 'org.gnome.shell'});
+const favorites = settings.get_strv('favorite-apps');
+settings.set_strv('favorite-apps', COSMIC_FAVORITES.concat(favorites));
+";
+
+pub fn update_favorites() -> anyhow::Result<()> {
+    let (uid_min, uid_max) = crate::misc::uid_min_max()?;
+
+    for user in unsafe { users::all_users() } {
+        if user.uid() >= uid_min && user.uid() <= uid_max {
+            let name = user.name();
+
+            info!("updating favorite-apps for {}", name.to_str().unwrap_or("<unkown>"));
+
+            if let Err(why) = update_favorites_for(name) {
+                error!(
+                     "failed to update favorite-apps for {}: {}",
+                     name.to_str().unwrap_or("<unknown>"),
+                     why
+                )
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn update_favorites_for(user: &std::ffi::OsStr) -> anyhow::Result<()> {
+    // If `dconf read` returns nothing, there is no entry in the user's dconf
+    // database, so gsettings will just use the system default
+    let is_default = Command::new("sudo")
+        .arg("-Hu")
+        .arg(user)
+        .args(&["dconf", "read", "/org/gnome/shell/favorite-apps"])
+        .output()?
+        .stdout
+        .is_empty();
+
+    // Otherwise if user has set favorites, prepend Cosmic favorites
+    if !is_default {
+        Command::new("sudo")
+            .arg("-Hu")
+            .arg(user)
+            .arg("dbus-launch")
+            .args(&["gjs", "-c", SETTINGS_JS_SCRIPT])
+            .status()
+            .map_result()?;
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub mod sighandler;
 pub mod system_environment;
 
 mod external;
+mod favorites;
 mod fetch;
 mod gnome_extensions;
 

--- a/src/release/mod.rs
+++ b/src/release/mod.rs
@@ -390,6 +390,8 @@ impl DaemonRuntime {
         let from_codename =
             Codename::try_from(from_version).expect("release doesn't have a codename");
 
+        let to_version = to.parse::<Version>().expect("invalid version");
+
         // Ensure that prerequest files and mounts are available.
         match action {
             UpgradeMethod::Offline => systemd::upgrade_prereq()?,
@@ -494,6 +496,15 @@ impl DaemonRuntime {
                 "failed to disable gnome-shell extensions: {}",
                 crate::misc::format_error(why.as_ref())
             )
+        }
+
+        if from_version.major < 21 && to_version.major >= 21 {
+            if let Err(why) = crate::favorites::update_favorites() {
+                error!(
+                    "failed to update favorite-apps: {}",
+                    crate::misc::format_error(why.as_ref())
+                )
+            }
         }
 
         (*logger)(UpgradeEvent::Success);


### PR DESCRIPTION
Without this, the launcher, workspaces, and applications buttons won't appear in the dock on upgraded systems (without manually adding them).

Haven't tested this in an actual upgrade yet, so still need to see if it works properly. Dconf might need a user dbus session...