### PR TITLE
fix: Prevent pop-upgrade service from running in an install environment

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,11 +53,17 @@ pub mod error {
 }
 
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+use std::path::Path;
 use std::process::exit;
 
 use self::error::InitError;
 
 pub fn main() {
+    // Service shall not run in a live environment.
+    if Path::new("/cdrom/casper/filesystem.squashfs").exists() {
+        exit(0);
+    }
+
     let _ = setup_logging(::log::LevelFilter::Debug);
 
     let clap = App::new("pop-upgrade")


### PR DESCRIPTION
Should fix session crashes