### PR TITLE
fix(shlibs): Update version to 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ endif
 
 VENDORED ?= 0
 ifeq ($(VENDORED),1)
-	ARGS += "--frozen"
+	ARGS += "--frozen" "--offline"
 endif
 
 BINARY=target/$(TARGET)/$(BIN)

--- a/debian/libpop-upgrade-gtk.shlibs
+++ b/debian/libpop-upgrade-gtk.shlibs
@@ -1,1 +1,1 @@
-libpop_upgrade_gtk 0 libpop-upgrade-gtk (>= 0.1.0~)
+libpop_upgrade_gtk 1 libpop-upgrade-gtk (>= 1.0.0~)


### PR DESCRIPTION
The soname version has changed since the version in `Cargo.toml` was changed to 1.0.0.

This fixes an error in `dh_shlibdeps` on my Gnome 40 branch of gnome-control-center.