### PR TITLE
fix(upgrade.sh): After upgrade, set default session for each user to pop

### DIFF
--- a/data/pop-upgrade.sh
+++ b/data/pop-upgrade.sh
@@ -3,6 +3,13 @@
 export LANG=C
 export DEBIAN_FRONTEND="noninteractive"
 
+# Sets default session for each user as as pop
+set_default_session () {
+    for $file in /var/lib/AccountsService/users/*; do
+        sed "s/^Session=.*/Session=pop/g" -i $file
+    done
+}
+
 # Prevent apt sources from being reverted once this script launches
 rm -rf /pop-upgrade /pop_preparing_release_upgrade
 
@@ -150,6 +157,8 @@ attempt_upgrade () {
     systemctl mask acpid pop-upgrade
 
     if (upgrade || attempt_repair); then
+        set_default_session
+
         rm -rf  /system-update "$1"
 
         message -i "Upgrade complete. Removing old kernels"
@@ -171,6 +180,7 @@ attempt_upgrade () {
         systemctl unmask acpid pop-upgrade
         systemctl reboot
     else
+        set_default_session
         message -f "Upgrade failed. Restarting the system to try again"
         sleep 6
         plymouth message --text="system-updates-stop"


### PR DESCRIPTION
This should resolve https://github.com/pop-os/beta/issues/236, in the event that an upgraded package sets itself as the default session.