### PR TITLE
fix(21.10): Remove /var/lib/bluetooth to resolve bluez issue

### DIFF
--- a/src/release/mod.rs
+++ b/src/release/mod.rs
@@ -471,6 +471,11 @@ pub async fn upgrade<'a>(
         )
     }
 
+    if to == "21.10" {
+        info!("removing /var/lib/bluetooth to resolve https://github.com/bluez/bluez/issues/157");
+        let _ = fs::remove_dir_all("/var/lib/bluetooth");
+    }
+
     (*logger)(UpgradeEvent::Success);
     Ok(())
 }


### PR DESCRIPTION
The journald logs for the pop-upgrade service should print a message about removing this directory after an upgrade is ready to be performed. The directory should be missing on shutdown.