### PR TITLE
minor refactoring and code quality

### DIFF
--- a/gtk/ffi/build.rs
+++ b/gtk/ffi/build.rs
@@ -14,6 +14,6 @@ fn main() {
 
     File::create(dbg!(target_dir.join("pop_upgrade_gtk.pc.stub")))
         .expect("failed to create pc.stub")
-        .write_all(&pkg_config.as_bytes())
+        .write_all(pkg_config.as_bytes())
         .expect("failed to write pc.stub");
 }

--- a/gtk/src/errors.rs
+++ b/gtk/src/errors.rs
@@ -48,7 +48,7 @@ impl<'a> Iterator for ErrorIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let current = self.current;
-        self.current = self.current.and_then(|why| why.source());
+        self.current = self.current.and_then(ErrorTrait::source);
         current
     }
 }

--- a/gtk/src/events/background/mod.rs
+++ b/gtk/src/events/background/mod.rs
@@ -31,7 +31,7 @@ pub enum BackgroundEvent {
 }
 
 pub fn run(
-    receiver: mpsc::Receiver<BackgroundEvent>,
+    receiver: &mpsc::Receiver<BackgroundEvent>,
     send: impl Fn(UiEvent) + Send + Sync + 'static,
 ) {
     let send: &dyn Fn(UiEvent) = &send;
@@ -65,11 +65,11 @@ pub fn run(
                         }
                     };
 
-                    send(event)
+                    send(event);
                 }
 
                 BackgroundEvent::DownloadUpgrade(info) => {
-                    self::release::download(client, send, info);
+                    self::release::download(client, send, &info);
                 }
 
                 BackgroundEvent::Finalize => match client.release_upgrade_finalize() {

--- a/gtk/src/events/background/mod.rs
+++ b/gtk/src/events/background/mod.rs
@@ -23,6 +23,7 @@ pub enum BackgroundEvent {
     GetStatus(DaemonStatus),
     IsActive(SyncSender<bool>),
     DismissNotification(bool),
+    #[allow(clippy::upper_case_acronyms)]
     RefreshOS,
     Reset,
     Scan,

--- a/gtk/src/events/background/release.rs
+++ b/gtk/src/events/background/release.rs
@@ -8,7 +8,7 @@ use pop_upgrade::{
     release::UpgradeMethod,
 };
 
-pub fn download(client: &Client, send: &dyn Fn(UiEvent), info: ReleaseInfo) {
+pub fn download(client: &Client, send: &dyn Fn(UiEvent), info: &ReleaseInfo) {
     info!("downloading updates for {}", info.next);
     if !update(client, send) {
         return;
@@ -58,14 +58,14 @@ pub fn download(client: &Client, send: &dyn Fn(UiEvent), info: ReleaseInfo) {
                 }
                 Signal::PackageFetched(status) => {
                     send(UiEvent::Progress(ProgressEvent::Fetching(
-                        status.completed as u64,
-                        status.total as u64,
+                        status.completed.into(),
+                        status.total.into(),
                     )));
                 }
                 Signal::PackageUpgrade(event) => {
                     match AptUpgradeEvent::from_dbus_map(event.into_iter()) {
                         Ok(AptUpgradeEvent::Progress { percent }) => {
-                            send(UiEvent::Progress(ProgressEvent::Updates(percent)))
+                            send(UiEvent::Progress(ProgressEvent::Updates(percent)));
                         }
                         Ok(AptUpgradeEvent::WaitingOnLock) => {
                             send(UiEvent::WaitingOnLock);
@@ -89,12 +89,6 @@ pub fn download(client: &Client, send: &dyn Fn(UiEvent), info: ReleaseInfo) {
                     }
 
                     return Ok(client::Continue(false));
-                }
-                Signal::RecoveryDownloadProgress(progress) => {
-                    send(UiEvent::Progress(ProgressEvent::Recovery(
-                        progress.progress,
-                        progress.total,
-                    )));
                 }
                 _ => (),
             }
@@ -129,8 +123,8 @@ pub fn update(client: &Client, send: &dyn Fn(UiEvent)) -> bool {
 
     if updates.updates_available {
         send(UiEvent::Progress(ProgressEvent::Fetching(
-            updates.completed as u64,
-            updates.total as u64,
+            updates.completed.into(),
+            updates.total.into(),
         )));
 
         let error = &mut None;
@@ -149,14 +143,14 @@ pub fn update(client: &Client, send: &dyn Fn(UiEvent)) -> bool {
                     }
                     Signal::PackageFetched(status) => {
                         send(UiEvent::Progress(ProgressEvent::Fetching(
-                            status.completed as u64,
-                            status.total as u64,
+                            status.completed.into(),
+                            status.total.into(),
                         )));
                     }
                     Signal::PackageUpgrade(event) => {
                         match AptUpgradeEvent::from_dbus_map(event.into_iter()) {
                             Ok(AptUpgradeEvent::Progress { percent }) => {
-                                send(UiEvent::Progress(ProgressEvent::Updates(percent)))
+                                send(UiEvent::Progress(ProgressEvent::Updates(percent)));
                             }
                             Ok(AptUpgradeEvent::WaitingOnLock) => {
                                 send(UiEvent::WaitingOnLock);

--- a/gtk/src/gtk_utils.rs
+++ b/gtk/src/gtk_utils.rs
@@ -1,7 +1,7 @@
 use gtk::prelude::*;
 
 pub fn scale_label(label: &gtk::Label, scale: f64) {
-    let list = label.get_attributes().unwrap_or_else(|| pango::AttrList::new());
+    let list = label.get_attributes().unwrap_or_default();
     list.insert(pango::Attribute::new_scale(scale).expect("new scale returned null"));
     label.set_attributes(Some(&list));
 }

--- a/gtk/src/lib.rs
+++ b/gtk/src/lib.rs
@@ -27,7 +27,11 @@ mod widgets;
 
 pub use localize::localizer;
 
-use self::{events::*, state::State, widgets::Section};
+use self::{
+    events::{BackgroundEvent, Event, EventWidgets},
+    state::State,
+    widgets::Section,
+};
 use gtk::prelude::*;
 use std::{
     cell::RefCell,
@@ -61,7 +65,7 @@ impl UpgradeWidget {
         let gui_sender = Arc::new(gui_sender);
 
         thread::spawn(enclose!((gui_sender) move || {
-            events::background::run(bg_receiver, move |event| {
+            events::background::run(&bg_receiver, move |event| {
                 let _ = gui_sender.send(event);
             });
         }));

--- a/gtk/src/lib.rs
+++ b/gtk/src/lib.rs
@@ -59,6 +59,7 @@ pub struct UpgradeWidget {
 }
 
 impl UpgradeWidget {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         let (bg_sender, bg_receiver) = mpsc::sync_channel(5);
         let (gui_sender, gui_receiver) = flume::unbounded();

--- a/gtk/src/main.rs
+++ b/gtk/src/main.rs
@@ -3,7 +3,7 @@ extern crate cascade;
 
 use gio::{prelude::*, ApplicationFlags};
 use gtk::{prelude::*, Application};
-use pop_upgrade_gtk::*;
+use pop_upgrade_gtk::UpgradeWidget;
 
 pub const APP_ID: &str = "com.system76.UpgradeManager";
 
@@ -125,7 +125,7 @@ fn install_logging(filter: LevelFilter) -> Result<(), InitError> {
                 format_level(record),
                 location(record),
                 message
-            ))
+            ));
         })
         .chain(io::stderr())
         .apply()?;

--- a/gtk/src/state.rs
+++ b/gtk/src/state.rs
@@ -1,4 +1,8 @@
-use crate::{events::*, widgets::Dismisser, ErrorCallback, EventCallback, ReadyCallback};
+use crate::{
+    events::{BackgroundEvent, UiEvent},
+    widgets::Dismisser,
+    ErrorCallback, EventCallback, ReadyCallback,
+};
 
 use pop_upgrade::client::ReleaseInfo;
 

--- a/gtk/src/users.rs
+++ b/gtk/src/users.rs
@@ -9,9 +9,8 @@ pub fn is_admin() -> bool {
 /// Check if a user is in an administrative group, such as `adm` or `sudo`.
 fn in_admin_group(user: &std::ffi::OsStr) -> bool {
     let in_group = |name| {
-        users::get_group_by_name(name).map_or(false, |group| {
-            group.members().into_iter().any(|member| member.as_os_str() == user)
-        })
+        users::get_group_by_name(name)
+            .map_or(false, |group| group.members().iter().any(|member| member.as_os_str() == user))
     };
 
     include_str!("admin-groups").lines().filter(|g| !g.is_empty()).any(in_group)

--- a/gtk/src/widgets/dialogs/mod.rs
+++ b/gtk/src/widgets/dialogs/mod.rs
@@ -23,7 +23,7 @@ impl DialogTemplate {
 
         let accept = cascade! {
             gtk::Button::with_label(accept);
-            ..get_style_context().add_class(&accept_style);
+            ..get_style_context().add_class(accept_style);
         };
 
         let dialog = gtk::DialogBuilder::new()

--- a/gtk/src/widgets/upgrade_option.rs
+++ b/gtk/src/widgets/upgrade_option.rs
@@ -127,7 +127,7 @@ impl UpgradeOption {
                 self.show_button();
                 let id = self.button.connect_clicked(move |button| {
                     button.hide();
-                    func()
+                    func();
                 });
                 *button_signal = Some(id);
             }
@@ -163,7 +163,7 @@ impl UpgradeOption {
     /// Set the progress bar to the exact percent as defined.
     pub fn progress_exact(&self, percent: u8) -> &Self {
         // Only set if the new progress is higher than the current.
-        let new = percent as f64 / 100f64;
+        let new = f64::from(percent) / 100f64;
         if new > self.progress.get_fraction() {
             self.progress.set_fraction(new);
         }
@@ -193,16 +193,13 @@ impl UpgradeOption {
 
     /// Sets a sublabel with additional information about the operation.
     pub fn sublabel(&self, label: Option<&str>) -> &Self {
-        match label {
-            Some(label) => {
-                self.label.set_yalign(1.0);
-                self.sublabel.set_label(label);
-                self.sublabel.show();
-            }
-            None => {
-                self.label.set_yalign(0.5);
-                self.sublabel.hide();
-            }
+        if let Some(label) = label {
+            self.label.set_yalign(1.0);
+            self.sublabel.set_label(label);
+            self.sublabel.show();
+        } else {
+            self.label.set_yalign(0.5);
+            self.sublabel.hide();
         }
 
         self

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -34,7 +34,7 @@ pub async fn validate_checksum(file: &mut File, checksum: &str) -> Result<(), Va
     }
 
     let found = hasher.finalize();
-    if &*found != &*expected {
+    if *found != *expected {
         return Err(ValidateError::Checksum {
             expected: checksum.into(),
             found:    format!("{:x}", found),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    daemon::{DaemonStatus as PrimaryStatus, *},
+    daemon::*,
     recovery::{RecoveryEvent, ReleaseFlags as RecoveryReleaseFlags},
     release::{RefreshOp, UpgradeEvent, UpgradeMethod},
     sighandler, DBUS_IFACE, DBUS_NAME, DBUS_PATH,
@@ -431,9 +431,7 @@ impl Client {
         self.bus.send_with_reply_and_block(m, TIMEOUT).map_err(|why| Error::Call(method, why))
     }
 
-    fn is_inactive(&self) -> Result<bool, Error> {
-        self.status().map(|status| status.status == 0)
-    }
+    fn is_inactive(&self) -> Result<bool, Error> { self.status().map(|status| status.status == 0) }
 }
 
 fn filter_signal(ci: ConnectionItem) -> Option<Message> {

--- a/src/daemon/error.rs
+++ b/src/daemon/error.rs
@@ -1,4 +1,3 @@
-use dbus;
 use std::io;
 use thiserror::Error;
 

--- a/src/external.rs
+++ b/src/external.rs
@@ -14,8 +14,7 @@ pub async fn findmnt_uuid<P: AsRef<Path>>(path: P) -> io::Result<String> {
 
     let reader = BufReader::new(child.stdout.take().unwrap());
 
-    match reader.lines().next().await {
-        Some(Ok(line)) => Ok(line),
-        _ => Err(io::Error::new(io::ErrorKind::NotFound, "findmnt: uuid not found for device"))?,
-    }
+    reader.lines().next().await.unwrap_or_else(|| {
+        Err(io::Error::new(io::ErrorKind::NotFound, "findmnt: uuid not found for device"))
+    })
 }

--- a/src/gnome_extensions.rs
+++ b/src/gnome_extensions.rs
@@ -25,7 +25,7 @@ fn extension_path(user: &str) -> String {
 fn disable_for(user: &str) {
     let path = extension_path(user);
 
-    if ! Path::new(&path).exists() {
+    if !Path::new(&path).exists() {
         return;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 #![deny(clippy::all)]
-#![allow(clippy::new_ret_no_self)]
-#![allow(clippy::useless_attribute)]
 
 #[macro_use]
 extern crate anyhow;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -42,7 +42,7 @@ pub fn setup_logging(filter: LevelFilter) -> Result<(), InitError> {
                 format_level(record),
                 location(record),
                 message
-            ))
+            ));
         })
         .chain(io::stderr())
         .apply()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,7 @@ fn main_(matches: &ArgMatches) -> anyhow::Result<()> {
                 _ => unreachable!(),
             };
 
-            func(&client, matches)?
+            func(&client, matches)?;
         }
         _ => unreachable!("clap argument parsing failed"),
     }

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -91,7 +91,7 @@ where
     }
 
     if let Some((version, build)) =
-        fetch_iso(cancel, verify, &action, &progress, &event, "/recovery").await?
+        fetch_iso(cancel, verify, action, &progress, &event, "/recovery").await?
     {
         let data = fomat!((version) " " (build));
         async_fs::write(RECOVERY_VERSION, data.as_bytes())
@@ -232,7 +232,7 @@ async fn from_release<'a, F: Fn(u64, u64) + 'static + Send + Sync>(
     _flags: ReleaseFlags,
 ) -> RecResult<PathBuf> {
     let arch = match arch {
-        Some(ref arch) => arch,
+        Some(arch) => arch,
         None => detect_arch()?,
     };
 

--- a/src/recovery/version.rs
+++ b/src/recovery/version.rs
@@ -65,7 +65,7 @@ pub fn version() -> Result<RecoveryVersion, RecoveryVersionError> {
             }
         }
 
-        return Err(RecoveryVersionError::Unknown);
+        Err(RecoveryVersionError::Unknown)
     }
 }
 

--- a/src/release/check.rs
+++ b/src/release/check.rs
@@ -12,13 +12,7 @@ pub enum BuildStatus {
 }
 
 impl BuildStatus {
-    pub fn is_ok(&self) -> bool {
-        if let BuildStatus::Build(_) = *self {
-            true
-        } else {
-            false
-        }
-    }
+    pub fn is_ok(&self) -> bool { matches!(*self, BuildStatus::Build(_)) }
 
     pub fn status_code(&self) -> i16 {
         match *self {
@@ -137,7 +131,7 @@ fn next_(
     // Only permits an upgrade if the development flag is passed
     let development_enabled = |is_lts: bool, current: &'static str, next: &'static str| {
         let build = if development { release_check(next) } else { BuildStatus::Blacklisted };
-        ReleaseStatus { build, current, is_lts, next }
+        ReleaseStatus { current, next, build, is_lts }
     };
 
     match (current.major, current.minor) {

--- a/src/release/errors.rs
+++ b/src/release/errors.rs
@@ -14,6 +14,7 @@ pub enum ReleaseError {
     AptPurge(#[source] io::Error),
 
     #[error("failed to back up system sources")]
+    #[allow(clippy::upper_case_acronyms)]
     BackupPPAs(#[source] anyhow::Error),
 
     #[error("unable to upgrade to next release: {:?}", _0)]
@@ -29,6 +30,7 @@ pub enum ReleaseError {
     CurrentUpdate(#[source] io::Error),
 
     #[error("unable to disable third party repositories")]
+    #[allow(clippy::upper_case_acronyms)]
     DisablePPAs(#[source] anyhow::Error),
 
     #[error("status for `dpkg --configure -a` failed")]

--- a/src/release/repos.rs
+++ b/src/release/repos.rs
@@ -117,7 +117,7 @@ pub fn disable_third_parties(release: &str) -> anyhow::Result<()> {
             for line in contents.lines() {
                 let trimmed = line.trim();
                 if trimmed.starts_with("deb") {
-                    replaced.push_str("# ")
+                    replaced.push_str("# ");
                 }
 
                 replaced.push_str(trimmed);
@@ -165,7 +165,7 @@ pub fn replace_with_old_releases() -> io::Result<()> {
         }
     };
 
-    for source in [SOURCES_LIST, SYSTEM_SOURCES].iter().cloned() {
+    for source in &[SOURCES_LIST, SYSTEM_SOURCES] {
         if let Ok(contents) = fs::read_to_string(source) {
             if let Some(changed) = replace(&contents) {
                 let _ = fs::write(source, changed.as_bytes());
@@ -330,11 +330,10 @@ X-Repolib-Default-Mirror: http://us.archive.ubuntu.com/ubuntu/
 }
 
 fn sources_list_placeholder() -> String {
-    format!(
-        r#"## This file is deprecated in Pop!_OS.
+    r#"## This file is deprecated in Pop!_OS.
 ## See `man deb822` and /etc/apt/sources.list.d/system.sources.
 "#
-    )
+    .to_string()
 }
 
 fn proprietary_sources(release: &str) -> String {

--- a/src/release/snapd.rs
+++ b/src/release/snapd.rs
@@ -15,7 +15,7 @@ pub async fn hold_transitional_packages() -> Result<(), ReleaseError> {
     let mut buffer = String::new();
 
     for package in &snap_packages {
-        buffer.push_str(&*package);
+        buffer.push_str(*package);
         buffer.push('\n');
     }
 

--- a/src/release/systemd.rs
+++ b/src/release/systemd.rs
@@ -55,7 +55,7 @@ impl BootConf {
     }
 
     /// Defines the specified entry as the default boot entry
-    pub fn set_default_boot_variant(&mut self, variant: LoaderEntry) -> anyhow::Result<()> {
+    pub fn set_default_boot_variant(&mut self, variant: &LoaderEntry) -> anyhow::Result<()> {
         self.set_default_boot(|conf| {
             let comparison: fn(filename: &str) -> bool = match variant {
                 LoaderEntry::Current => |e| e.to_lowercase().ends_with("current"),
@@ -124,7 +124,7 @@ pub fn upgrade_prereq() -> RelResult<()> {
 
     let invalid = REQUIRED_UPGRADE_FILES
         .iter()
-        .cloned()
+        .copied()
         .filter(|file| !Path::new(file).is_file())
         .collect::<Vec<&'static str>>();
 

--- a/src/release_api.rs
+++ b/src/release_api.rs
@@ -33,7 +33,7 @@ impl RawRelease {
     fn into_release(self) -> Result<Release, ApiError> {
         let RawRelease { version, url, size, sha_sum, channel, build, urgent } = self;
         let build = build.parse::<u16>().map_err(|_| ApiError::BuildNaN(build))?;
-        let urgent = if urgent == "true" { true } else { false };
+        let urgent = urgent == "true";
 
         Ok(Release { version, url, size, sha_sum, channel, build, urgent })
     }

--- a/src/repair/crypttab.rs
+++ b/src/repair/crypttab.rs
@@ -32,7 +32,7 @@ fn cryptswap_plain_warning(input: &str) -> Option<String> {
             continue;
         }
 
-        if let Some(options) = line.split_ascii_whitespace().skip(3).next() {
+        if let Some(options) = line.split_ascii_whitespace().nth(3) {
             let fields = options.split(',').collect::<Vec<_>>();
             if fields.iter().any(|&e| e == "swap") && !fields.iter().any(|&e| e == "plain") {
                 new.push_str(&line.replace("swap,", "swap,plain,"));

--- a/src/repair/misc.rs
+++ b/src/repair/misc.rs
@@ -27,19 +27,17 @@ pub fn dkms_gcc9_fix() -> io::Result<()> {
             )
         })?;
 
-    for dir in fs::read_dir(lib_modules_dir)? {
-        if let Ok(dir) = dir {
-            if let Some(file_name) = dir.file_name().to_str() {
-                if human_sort::compare(&file_name, UNAFFECTED) == Ordering::Less {
-                    let makefile = dir.path().join("build/Makefile");
-                    if makefile.exists() {
-                        let mut data = fs::read_to_string(&makefile)?;
-                        let mut file = File::create(&makefile)?;
+    for dir in fs::read_dir(lib_modules_dir)?.flatten() {
+        if let Some(file_name) = dir.file_name().to_str() {
+            if human_sort::compare(file_name, UNAFFECTED) == Ordering::Less {
+                let makefile = dir.path().join("build/Makefile");
+                if makefile.exists() {
+                    let mut data = fs::read_to_string(&makefile)?;
+                    let mut file = File::create(&makefile)?;
 
-                        data = data.replace(BADFLAGS[0], "");
-                        data = data.replace(BADFLAGS[1], "");
-                        file.write_all(data.as_bytes())?;
-                    }
+                    data = data.replace(BADFLAGS[0], "");
+                    data = data.replace(BADFLAGS[1], "");
+                    file.write_all(data.as_bytes())?;
                 }
             }
         }

--- a/src/repair/mod.rs
+++ b/src/repair/mod.rs
@@ -35,7 +35,7 @@ pub async fn repair() -> Result<(), RepairError> {
 
     crypttab::repair().map_err(RepairError::Crypttab)?;
     fstab::repair().map_err(RepairError::Fstab)?;
-    packaging::repair(&release).await.map_err(RepairError::Packaging)?;
+    packaging::repair(release).await.map_err(RepairError::Packaging)?;
 
     Ok(())
 }


### PR DESCRIPTION
what it says on the tin.

for reference, i'm using the following configuration to hunt these down-

```
cargo +nightly clippy --all-targets --all-features --workspace -- -W clippy::all -W clippy::pedantic -A clippy::must_use_candidate -A clippy::let_underscore_drop -A clippy::missing_errors_doc -A clippy::missing_panics_doc -A clippy::map_unwrap_or -A clippy::module_name_repetitions -A clippy::cast_possible_truncation
```
I also have clippy's msrv configured as per #245

the 'allowed' lints are simply to reduce some of the noise in the warnings. IMO the allowed lints should either be addressed or explicitly whitelisted in the crate root

there's a lot of overlap with #210 i'm afraid