### PR TITLE
change global object from 'const' to 'static'

### DIFF
--- a/gtk/src/events/mod.rs
+++ b/gtk/src/events/mod.rs
@@ -404,7 +404,7 @@ fn download_complete(state: &mut State, widgets: &EventWidgets) {
 
 use once_cell::sync::Lazy;
 
-const GENERIC: Lazy<String> = Lazy::new(|| {
+static GENERIC: Lazy<String> = Lazy::new(|| {
     fomat!(
         (fl!("error-header")) "\n\n"
         "* /etc/apt/sources.list\n"


### PR DESCRIPTION
an interior-mutable object shouldn't be declared as `const`

see [this reference](https://rust-lang.github.io/rust-clippy/v0.0.212/#declare_interior_mutable_const)

> Consts are copied everywhere they are referenced, i.e. every time you refer to the const a fresh instance of the Cell or Mutex or AtomicXxxx will be created, which defeats the whole purpose of using these types in the first place. The const should better be replaced by a static item if a global variable is wanted, or replaced by a const fn if a constructor is wanted.
> 
> Example
> ```rust
> use std::sync::atomic::{Ordering::SeqCst, AtomicUsize};
> 
> // Bad.
> const CONST_ATOM: AtomicUsize = AtomicUsize::new(12);
> CONST_ATOM.store(6, SeqCst);             // the content of the atomic is unchanged
> assert_eq!(CONST_ATOM.load(SeqCst), 12); // because the CONST_ATOM in these lines are distinct
> 
> // Good.
> static STATIC_ATOM: AtomicUsize = AtomicUsize::new(15);
> STATIC_ATOM.store(9, SeqCst);
> assert_eq!(STATIC_ATOM.load(SeqCst), 9); // use a `static` item to refer to the same instance
> ```