### PR TITLE
Deferred Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 [[package]]
 name = "async-cron-scheduler"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/system-updater?branch=master#36436e2a98c87df6b0f5f4ffd41b51191ba02d39"
+source = "git+https://github.com/pop-os/system-updater?branch=upgrade#afe4fac791b2122a0128c6fd19568d5f11525334"
 dependencies = [
  "chrono",
  "cron",
@@ -2528,7 +2528,7 @@ checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
 [[package]]
 name = "pop-system-updater"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/system-updater?branch=master#36436e2a98c87df6b0f5f4ffd41b51191ba02d39"
+source = "git+https://github.com/pop-os/system-updater?branch=upgrade#afe4fac791b2122a0128c6fd19568d5f11525334"
 dependencies = [
  "anyhow",
  "apt-cmd",
@@ -2561,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "pop-system-updater-gtk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/system-updater?branch=master#36436e2a98c87df6b0f5f4ffd41b51191ba02d39"
+source = "git+https://github.com/pop-os/system-updater?branch=upgrade#afe4fac791b2122a0128c6fd19568d5f11525334"
 dependencies = [
  "cascade 1.0.0",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 [[package]]
 name = "async-cron-scheduler"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/system-updater?branch=upgrade#afe4fac791b2122a0128c6fd19568d5f11525334"
+source = "git+https://github.com/pop-os/system-updater#93fe6dc5137c84f8946037b157ceac6ffc1bd233"
 dependencies = [
  "chrono",
  "cron",
@@ -2528,7 +2528,7 @@ checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
 [[package]]
 name = "pop-system-updater"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/system-updater?branch=upgrade#afe4fac791b2122a0128c6fd19568d5f11525334"
+source = "git+https://github.com/pop-os/system-updater#93fe6dc5137c84f8946037b157ceac6ffc1bd233"
 dependencies = [
  "anyhow",
  "apt-cmd",
@@ -2561,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "pop-system-updater-gtk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/system-updater?branch=upgrade#afe4fac791b2122a0128c6fd19568d5f11525334"
+source = "git+https://github.com/pop-os/system-updater#93fe6dc5137c84f8946037b157ceac6ffc1bd233"
 dependencies = [
  "cascade 1.0.0",
  "chrono",

--- a/daemon/src/release/check.rs
+++ b/daemon/src/release/check.rs
@@ -140,11 +140,13 @@ async fn next_<Check: Fn(String) -> Status, Status: Future<Output = BuildStatus>
         (20, 4) => available(true, FOCAL, JAMMY).await,
         (20, 10) => available(false, GROOVY, HIRSUTE).await,
         (21, 4) => available(false, HIRSUTE, IMPISH).await,
-        (21, 10) => if cfg!(target_arch = "x86_64") {
-            available(false, IMPISH, JAMMY).await
-        } else {
-            development_enabled(false, IMPISH, JAMMY).await
-        },
+        (21, 10) => {
+            if cfg!(target_arch = "x86_64") {
+                available(false, IMPISH, JAMMY).await
+            } else {
+                development_enabled(false, IMPISH, JAMMY).await
+            }
+        }
         (22, 4) => blocked(true, JAMMY, UNKNOWN).await,
         _ => panic!("this version of pop-upgrade is not supported on this release"),
     }

--- a/daemon/src/release/mod.rs
+++ b/daemon/src/release/mod.rs
@@ -241,10 +241,9 @@ async fn apt_fetch_(
         .retries(3)
         .connections_per_file(1)
         .timeout(std::time::Duration::from_secs(15))
-        .delay_between_requests(100)
         .shutdown(shutdown.clone())
         .into_package_fetcher()
-        .concurrent(1)
+        .concurrent(2)
         .fetch(fetch_rx.into_stream(), Arc::from(Path::new(ARCHIVES)));
 
     tokio::spawn(fetcher);

--- a/daemon/src/release/mod.rs
+++ b/daemon/src/release/mod.rs
@@ -46,8 +46,9 @@ pub const STARTUP_UPGRADE_FILE: &str = "/pop-upgrade";
 /// - `gnome-software` conflicts with `pop-desktop` and its `sessioninstaller` dependency
 /// - `ureadahead` was deprecated and removed from the repositories
 /// - `update-notifier-common` breaks debconf and it's not part of a Pop install
+/// - `nodejs` may have some dependencies which are unmet on 22.04
 const REMOVE_PACKAGES: &[&str] =
-    &["irqbalance", "ureadahead", "backport-iwlwifi-dkms", "update-notifier-common"];
+    &["irqbalance", "ureadahead", "backport-iwlwifi-dkms", "update-notifier-common", "nodejs"];
 
 /// Packages which should be installed before upgrading.
 ///

--- a/daemon/src/release/mod.rs
+++ b/daemon/src/release/mod.rs
@@ -587,9 +587,9 @@ async fn fetch_new_release_packages<'b>(
         (logger)(UpgradeEvent::UpdatingPackageLists);
         AptGet::new().noninteractive().update().await.map_err(ReleaseError::ReleaseUpdate)?;
 
-        snapd::hold_transitional_packages().await?;
-
         attempt_fetch(&Shutdown::new(), logger, fetch).await?;
+
+        snapd::hold_transitional_packages().await?;
 
         info!("packages fetched successfully");
 

--- a/daemon/src/release/mod.rs
+++ b/daemon/src/release/mod.rs
@@ -45,7 +45,9 @@ pub const STARTUP_UPGRADE_FILE: &str = "/pop-upgrade";
 ///
 /// - `gnome-software` conflicts with `pop-desktop` and its `sessioninstaller` dependency
 /// - `ureadahead` was deprecated and removed from the repositories
-const REMOVE_PACKAGES: &[&str] = &["irqbalance", "ureadahead", "backport-iwlwifi-dkms"];
+/// - `update-notifier-common` breaks debconf and it's not part of a Pop install
+const REMOVE_PACKAGES: &[&str] =
+    &["irqbalance", "ureadahead", "backport-iwlwifi-dkms", "update-notifier-common"];
 
 /// Packages which should be installed before upgrading.
 ///

--- a/daemon/src/release/mod.rs
+++ b/daemon/src/release/mod.rs
@@ -463,7 +463,10 @@ pub async fn upgrade<'a>(
     if !conflicting.is_empty() {
         apt_lock_wait().await;
         (logger)(UpgradeEvent::RemovingConflicts);
-        crate::misc::apt_get().remove(conflicting).await.map_err(ReleaseError::ConflictRemoval)?;
+        let mut apt_get = crate::misc::apt_get();
+
+        apt_get.arg("--auto-remove");
+        apt_get.remove(conflicting).await.map_err(ReleaseError::ConflictRemoval)?;
     }
 
     // Update the package lists for the current release.

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -38,4 +38,3 @@ yansi = "0.5.1"
 
 [dependencies.pop-system-updater-gtk]
 git = "https://github.com/pop-os/system-updater"
-branch = "upgrade"

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -38,4 +38,4 @@ yansi = "0.5.1"
 
 [dependencies.pop-system-updater-gtk]
 git = "https://github.com/pop-os/system-updater"
-branch = "master"
+branch = "upgrade"

--- a/gtk/src/events/mod.rs
+++ b/gtk/src/events/mod.rs
@@ -123,7 +123,7 @@ impl EventWidgets {
     }
 }
 
-pub async fn on_event(widgets: &mut EventWidgets, state: &mut State, event: UiEvent) {
+pub async fn on_event(widgets: &mut EventWidgets, state: &mut State, event: UiEvent) -> bool {
     debug!("{:?}", event);
     match event {
         UiEvent::Progress(event) => match event {
@@ -183,9 +183,9 @@ pub async fn on_event(widgets: &mut EventWidgets, state: &mut State, event: UiEv
 
         // Events pertaining to the upgrade section
         UiEvent::Upgrade(event) => match event {
-            OsUpgradeEvent::Cancelled => cancelled_upgrade(state, &widgets),
+            OsUpgradeEvent::Cancelled => cancelled_upgrade(state, widgets),
 
-            OsUpgradeEvent::Dialog => release_upgrade_dialog(state, &widgets),
+            OsUpgradeEvent::Dialog => release_upgrade_dialog(state, widgets),
 
             OsUpgradeEvent::Dismissed(dismissed) => {
                 info!("{} release", if dismissed { "dismissed" } else { "un-dismissed" });
@@ -207,7 +207,7 @@ pub async fn on_event(widgets: &mut EventWidgets, state: &mut State, event: UiEv
 
             OsUpgradeEvent::Notification => (state.callback_ready.borrow())(),
 
-            OsUpgradeEvent::Upgrade => upgrade_clicked(state, &widgets),
+            OsUpgradeEvent::Upgrade => upgrade_clicked(state, widgets),
         },
 
         UiEvent::Updating => {
@@ -248,12 +248,12 @@ pub async fn on_event(widgets: &mut EventWidgets, state: &mut State, event: UiEv
                 }
             }
 
-            OsRecoveryEvent::Update => recovery::clicked(state, &widgets),
+            OsRecoveryEvent::Update => recovery::clicked(state, widgets),
         },
 
         UiEvent::Completed(event) => match event {
             CompletedEvent::Download => {
-                download_complete(state, &widgets);
+                download_complete(state, widgets);
             }
 
             CompletedEvent::Recovery(enable_refresh) => {
@@ -269,7 +269,7 @@ pub async fn on_event(widgets: &mut EventWidgets, state: &mut State, event: UiEv
 
             CompletedEvent::Scan(event) => {
                 widgets.stack.set_visible_child_name("updated");
-                scan_event(state, &widgets, event);
+                scan_event(state, widgets, event);
             }
         },
 
@@ -278,12 +278,14 @@ pub async fn on_event(widgets: &mut EventWidgets, state: &mut State, event: UiEv
             let _ = state.sender.send(BackgroundEvent::GetStatus(from));
         }
 
-        UiEvent::Error(why) => error(state, &widgets, &why),
+        UiEvent::Error(why) => error(state, widgets, &why),
 
         UiEvent::WaitingOnLock => (),
 
-        UiEvent::Shutdown => return,
+        UiEvent::Shutdown => return false,
     }
+
+    true
 }
 
 /// On a cancelled upgrade, reset the widget to its pre-upgrade status.

--- a/gtk/src/widgets/dialogs/mod.rs
+++ b/gtk/src/widgets/dialogs/mod.rs
@@ -24,7 +24,7 @@ impl DialogTemplate {
         let accept = cascade! {
             gtk::Button::with_label(accept);
             ..style_context().add_class(accept_style);
-            ..style_context().add_class(&accept_style);
+            ..style_context().add_class(accept_style);
         };
 
         let dialog = gtk::Dialog::builder()


### PR DESCRIPTION
- Relies on upgrade branch at https://github.com/pop-os/system-updater/pull/6
- Unholds all packages that might be held before setting up a release upgrade
- Removes two potentially-problematic packages (update-notifier-common and nodejs)
- Performs an autoremove when removing packages
- Holds snap packages after fetching
- 2 concurrent package fetches with 0ms delay between requests
- GTK panel is scrollable with https://github.com/pop-os/gnome-control-center/pull/227