### PR TITLE
feat: re-enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,5 @@
 [workspace]
 members = [ "daemon", "gtk", "gtk/ffi"]
+
+[profile.release]
+lto = "fat"


### PR DESCRIPTION
Hi!

I started a discussion about enabling Link-Time Optimization (LTO) across all pop!_os projects to improve their general performance (more compiler optimizations can be done with LTO) and the binary size reduction (LTO usually leads to measurable binary size improvements) here - https://github.com/pop-os/pop/discussions/3386 . In https://github.com/pop-os/pop/discussions/3386#discussioncomment-10909426 was proposed creating PRs into repos with enabling LTO - it's such a PR!

As a reference, I used the `cosmic-comp` Release [profile](https://github.com/pop-os/cosmic-comp/blob/master/Cargo.toml#L116).

I see that in this project LTO was already enabled in [this](https://github.com/pop-os/upgrade/commit/bd1780b8aa1d0838ddfff3c6336d37c2bad41f77) commit but disabled [here](https://github.com/pop-os/upgrade/commit/15bc2f5518ca7dc4fb689f4c814b915ba16731c1) without comments. Maybe it was just a mistake. If there are actual reasons for disabling LTO here, please let me know. Maybe we can try to mitigate these reasons via the Thin LTO mode instead of Fat LTO.