### PR TITLE
fix: Remove epapirus before downgrading papirus

### DIFF
--- a/daemon/src/release/mod.rs
+++ b/daemon/src/release/mod.rs
@@ -509,6 +509,16 @@ async fn downgrade_packages() -> Result<(), ReleaseError> {
         if package.contains("pop-upgrade") || package.contains("pop-system-updater") {
             continue;
         }
+        
+        // Papirus's elementary variant must be removed prior to downgrading the main package.
+        if package.contains("papirus-icon-theme") {
+            info!("papirus-icon-theme will be downgraded, so removing epapirus-icon-theme");
+            let mut remove_epapirus_cmd = AptGet::new().allow_downgrades().force().noninteractive();
+            remove_epapirus_cmd.arg("remove");
+            remove_epapirus_cmd.arg("epapirus-icon-theme");
+            let _remove_epapirus = remove_epapirus_cmd.status().await
+                .context("apt-get remove epapirus-icon-theme").map_err(ReleaseError::Downgrade);
+        }
 
         if let Some(version) = version.split_ascii_whitespace().next() {
             cmd.arg([&package, "=", version].concat());


### PR DESCRIPTION
This definitely needs an engineering review (I wasn't sure what the best way to do this would be), but I've tested and confirmed that this does fix #337.

Testing checklist:
- [X] Runs successfully if both `papirus-icon-theme` and `epapirus-icon-theme` are installed
    - Used to fail, now works.
- [X] Runs successfully if `papirus-icon-theme` is installed but `epapirus-icon-theme` is not
    - `Package 'epapirus-icon-theme' is not installed, so not removed` is now logged; no adverse effects.
- ~~[ ] Runs successfully if `epapirus-icon-theme` is installed but `papirus-icon-theme` is not~~
    - Not a possible configuration; `epapirus-icon-theme` hard-depends on `papirus-icon-theme`. (If it were possible, `epapirus-icon-theme` may get removed anyway because it'd be orphaned after removing its PPA, but if it wasn't removed, it still shouldn't cause any problems since `papirus-icon-theme` wouldn't be upgraded on top of it in a scenario where it wasn't already installed by this point in the process.)
- [X] Runs successfully if neither Papirus packages are installed