### PR TITLE
fix: Add missing punctuation to string

### DIFF
--- a/i18n/bn/pop_upgrade_gtk.ftl
+++ b/i18n/bn/pop_upgrade_gtk.ftl
@@ -83,7 +83,7 @@ refresh-header = রিফ্রেশ ওএস
 
 release-current = সবচেয়ে আধুনিক {-os} সংস্করণ তুমি চালাচ্ছ
 
-upgrade-available = {-os} {$version} এসেছে
+upgrade-available = {-os} {$version} এসেছে!
 upgrade-canceling = হালনাগাদ বাতিল করা হচ্ছে
 upgrade-downloading = {-os} বর্তমানে নামানো হচ্ছে
 upgrade-from-to = যখন আসবে তখন {$current} থেকে {$next} এ হালনাগাদ করবে

--- a/i18n/cs/pop_upgrade_gtk.ftl
+++ b/i18n/cs/pop_upgrade_gtk.ftl
@@ -84,7 +84,7 @@ refresh-header = Přeinstalace OS
 
 release-current = Používáte nejnovější verzi {-os}
 
-upgrade-available = {-os} {$version} je k dizpozici
+upgrade-available = {-os} {$version} je k dizpozici!
 upgrade-canceling = Rušení upgrade
 upgrade-downloading = {-os}  se stahuje
 upgrade-from-to = Aktualizace z {$current} na {$next} je k dizpozici

--- a/i18n/da/pop_upgrade_gtk.ftl
+++ b/i18n/da/pop_upgrade_gtk.ftl
@@ -84,7 +84,7 @@ refresh-header = Nulstil operativsystemet
 
 release-current = Du kører den nyeste {-os} version
 
-upgrade-available = {-os} {$version} er tilgængelig
+upgrade-available = {-os} {$version} er tilgængelig!
 upgrade-canceling = Annullerer opgradering
 upgrade-downloading = {-os} downloader i øjeblikket
 upgrade-from-to = opgradering fra {$current} til {$next} er tilgængelig

--- a/i18n/de/pop_upgrade_gtk.ftl
+++ b/i18n/de/pop_upgrade_gtk.ftl
@@ -83,7 +83,7 @@ refresh-header = Grundinstallation wiederherstellen
 
 release-current = Sie benutzen die aktuellste {-os} Version
 
-upgrade-available = {-os} {$version} ist verfügbar
+upgrade-available = {-os} {$version} ist verfügbar!
 upgrade-canceling = Aktualisierung abbrechen
 upgrade-downloading = {-os} wird derzeit heruntergeladen
 upgrade-from-to = Aktualisierung von {$current} zu {$next} ist verfügbar

--- a/i18n/en/pop_upgrade_gtk.ftl
+++ b/i18n/en/pop_upgrade_gtk.ftl
@@ -84,7 +84,7 @@ refresh-header = Refresh OS
 
 release-current = You are running the most current {-os} version
 
-upgrade-available = {-os} {$version} is available
+upgrade-available = {-os} {$version} is available!
 upgrade-canceling = Canceling upgrade
 upgrade-downloading = {-os} is currently downloading
 upgrade-from-to = Upgrade from {$current} to {$next} is available

--- a/i18n/es/pop_upgrade_gtk.ftl
+++ b/i18n/es/pop_upgrade_gtk.ftl
@@ -83,7 +83,7 @@ refresh-header = Actualizar el SO
 
 release-current = Está ejecutando la versión más actual de {-os}
 
-upgrade-available = {-os} {$version} está disponible
+upgrade-available = {-os} {$version} está disponible!
 upgrade-canceling = Cancelando la actualización
 upgrade-downloading = {-os} está descargando
 upgrade-from-to = La actualización de {$current} a {$next} está disponible

--- a/i18n/fr/pop_upgrade_gtk.ftl
+++ b/i18n/fr/pop_upgrade_gtk.ftl
@@ -83,7 +83,7 @@ refresh-header = Mettre à jour l'OS
 
 release-current = Vous avez la version la plus récente de {-os}
 
-upgrade-available = {-os} {$version} est disponible
+upgrade-available = {-os} {$version} est disponible!
 upgrade-canceling = Annulation de la mise à niveau
 upgrade-downloading = {-os} est en cours de téléchargement
 upgrade-from-to = Une mise à niveau de {$current} à {$next} est disponible

--- a/i18n/hu/pop_upgrade_gtk.ftl
+++ b/i18n/hu/pop_upgrade_gtk.ftl
@@ -84,7 +84,7 @@ refresh-header = Rendszer helyreállítása
 
 release-current = A(z) {-os} legújabb verzióját használja.
 
-upgrade-available = {-os} {$version} elérhető
+upgrade-available = {-os} {$version} elérhető!
 upgrade-canceling = Rendszerfrissítés megszakítása
 upgrade-downloading = A(z) {-os} letöltése folyamatban
 upgrade-from-to = Frissítés a(z) {$current} verzióról a(z) {$next} verzióra

--- a/i18n/ja/pop_upgrade_gtk.ftl
+++ b/i18n/ja/pop_upgrade_gtk.ftl
@@ -84,7 +84,7 @@ refresh-header = OSのリフレッシュ
 
 release-current = 最新の {-os} バージョンを実行しています
 
-upgrade-available = {-os} {$version} が利用可能
+upgrade-available = {-os} {$version} が利用可能!
 upgrade-canceling = アップグレードをキャンセル中
 upgrade-downloading = 現在 {-os} をダウンロード中
 upgrade-from-to = {$current} から {$next} へアップグレードが可能

--- a/i18n/nb-NO/pop_upgrade_gtk.ftl
+++ b/i18n/nb-NO/pop_upgrade_gtk.ftl
@@ -83,7 +83,7 @@ refresh-header = Oppdater OS
 
 release-current = Du kjører den nyeste {-os} versjonen
 
-upgrade-available = {-os} {$version} er tilgjengelig
+upgrade-available = {-os} {$version} er tilgjengelig!
 upgrade-canceling = Avbryter oppgraderingen
 upgrade-downloading = {-os} lastes ned for øyeblikket
 upgrade-from-to = Oppgradering fra {$current} til {$next} er tilgjengelig

--- a/i18n/nl/pop_upgrade_gtk.ftl
+++ b/i18n/nl/pop_upgrade_gtk.ftl
@@ -84,7 +84,7 @@ refresh-header = Systeemherstel
 
 release-current = U beschikt over de nieuwste versie: {-os}
 
-upgrade-available = {-os} {$version} is beschikbaar
+upgrade-available = {-os} {$version} is beschikbaar!
 upgrade-canceling = Bezig met afbreken…
 upgrade-downloading = {-os} wordt gedownload
 upgrade-from-to = Er is een upgrade van {$current} naar {$next} beschikbaar

--- a/i18n/pl/pop_upgrade_gtk.ftl
+++ b/i18n/pl/pop_upgrade_gtk.ftl
@@ -84,7 +84,7 @@ refresh-header = Odśwież system operacyjny
 
 release-current = Używasz najnowszej wersji {-os}
 
-upgrade-available = {-os} {$version} jest dostępna
+upgrade-available = {-os} {$version} jest dostępna!
 upgrade-canceling = Anulowanie uaktualnienia
 upgrade-downloading = {-os} jest w trakcie pobierania
 upgrade-from-to = Uaktualnienie z {$current} do {$next} jest dostępne

--- a/i18n/pt-BR/pop_upgrade_gtk.ftl
+++ b/i18n/pt-BR/pop_upgrade_gtk.ftl
@@ -84,7 +84,7 @@ refresh-header = Reparar o Sistema Operacional
 
 release-current = Você está rodando a versão mais recente do {-os}
 
-upgrade-available = {-os} {$version} está disponível
+upgrade-available = {-os} {$version} está disponível!
 upgrade-canceling = Cancelando atualização
 upgrade-downloading = {-os} está sendo baixado
 upgrade-from-to = Atualização do {$current} para o {$next} está disponível

--- a/i18n/ru/pop_upgrade_gtk.ftl
+++ b/i18n/ru/pop_upgrade_gtk.ftl
@@ -84,7 +84,7 @@ refresh-header = Восстановить ОС
 
 release-current = У вас установлена последняя версия {-os}
 
-upgrade-available = {-os} {$version} доступна
+upgrade-available = {-os} {$version} доступна!
 upgrade-canceling = Отмена обновления
 upgrade-downloading = {-os} загружается
 upgrade-from-to = Доступно обновление с {$current} до {$next}

--- a/i18n/sl/pop_upgrade_gtk.ftl
+++ b/i18n/sl/pop_upgrade_gtk.ftl
@@ -83,7 +83,7 @@ refresh-header = Osveži OS
 
 release-current = Uporabljate najnovejšo različico {-os}
 
-upgrade-available = {-os} {$version} je navoljo
+upgrade-available = {-os} {$version} je navoljo!
 upgrade-canceling = Preklic nadgradnje
 upgrade-downloading = {-os} se trenutno prenaša
 upgrade-from-to = Na voljo je nadgradnja s {$current} na {$next}

--- a/i18n/sr/pop_upgrade_gtk.ftl
+++ b/i18n/sr/pop_upgrade_gtk.ftl
@@ -83,7 +83,7 @@ refresh-header = Osveži OS
 
 release-current = Trenutno je instalirana najnovija vezija {-os}-a
 
-upgrade-available = {-os} {$version} je dostupan
+upgrade-available = {-os} {$version} je dostupan!
 upgrade-canceling = Prekidanje nadogradnje
 upgrade-downloading = {-os} se trenutno preuzima
 upgrade-from-to = Nadogradnja sa {$current} na {$next} je dostupna

--- a/i18n/tr/pop_upgrade_gtk.ftl
+++ b/i18n/tr/pop_upgrade_gtk.ftl
@@ -83,7 +83,7 @@ refresh-header = İşletim Sistemini Tazele
 
 release-current = En güncel {-os} sürümüne sahipsiniz
 
-upgrade-available = {-os} {$version} sürüm yükseltmesi mevcut
+upgrade-available = {-os} {$version} sürüm yükseltmesi mevcut!
 upgrade-canceling = Yükseltme iptal ediliyor.
 upgrade-downloading = {-os} indiriliyor
 upgrade-from-to = {$current} sürümünden {$next} sürümüne bir yükseltme mevcut

--- a/i18n/uk/pop_upgrade_gtk.ftl
+++ b/i18n/uk/pop_upgrade_gtk.ftl
@@ -84,7 +84,7 @@ refresh-header = Скинути ОС
 
 release-current = Ви використовуєте найостаннішу версію {-os}
 
-upgrade-available = Доступне оновлення {-os} {$version}
+upgrade-available = Доступне оновлення {-os} {$version}!
 upgrade-canceling = Скасувати оновлення
 upgrade-downloading = {-os} наразі завантажується
 upgrade-from-to = Доступне оновлення з {$current} до {$next}

--- a/i18n/zh-CN/pop_upgrade_gtk.ftl
+++ b/i18n/zh-CN/pop_upgrade_gtk.ftl
@@ -84,7 +84,7 @@ refresh-header = 刷新操作系统
 
 release-current = 你正在运行最新的 {-os} 版本
 
-upgrade-available = {-os} {$version} 可升级
+upgrade-available = {-os} {$version} 可升级!
 upgrade-canceling = 正在取消升级系统
 upgrade-downloading = {-os} 现在正在下载
 upgrade-from-to = 从 {$current} 升级到 {$next} 已准备好


### PR DESCRIPTION
This fixes #181. Before:

![Screenshot_2025-03-28_14-51-50](https://github.com/user-attachments/assets/9547f131-97ee-44a2-9a1c-ae2aafcd70e2)

After:

![VirtualBox_Pop!_OS 20](https://github.com/user-attachments/assets/96aa51df-8372-4db8-b0e9-b67a2b0928d8)

It does also add the exclamation mark on the main Upgrade page when a new version's available, which seems fine. The alternative would be separating them out into different strings.

I'm not an expert on punctuation across languages, but it seems better to add it to everything than to leave some of the languages missing a separator between the sentences. I'm expecting we'll get follow-up PRs from translators if there are any languages where an exclamation mark can't be used like this.