### PR TITLE
fix: Handle PulseAudio path as file or directory

### DIFF
--- a/daemon/src/repair/misc.rs
+++ b/daemon/src/repair/misc.rs
@@ -51,7 +51,11 @@ pub fn wipe_pulse() -> io::Result<()> {
     for user in pwd::Passwd::iter() {
         let path = Path::new(&*user.dir).join(".config/pulse");
         if path.exists() {
-            std::fs::remove_dir_all(&path)?;
+            if path.is_dir() {
+                std::fs::remove_dir_all(&path)?;
+            } else {
+                std::fs::remove_file(&path)?;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/pop-os/upgrade/issues/322.

Performed three tests:

- [X] Still works with default `~/.config/pulse` directory.
- [X] Now works if `~/.config/pulse` is a file (used to fail before this change).
- [X] Still works if `~/.config/pulse` doesn't exist.