### PR TITLE
packaging: dpkg upgrade error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+debian/*
 !debian/*.install
 !debian/*.postinst
 !debian/changelog
@@ -7,7 +8,6 @@
 !debian/source
 .cargo/
 **/*.rs.bk
-debian/
 gtk/ffi/examples/c/build
 target/
 vendor.tar

--- a/debian/rules
+++ b/debian/rules
@@ -1,24 +1,10 @@
 #!/usr/bin/make -f
 
-export VENDOR ?= 1
-CLEAN ?= 1
-
 %:
-	dh $@ --with=systemd
+	dh $@
 
 override_dh_auto_clean:
-ifeq ($(CLEAN),1)
-	make clean
-endif
-ifeq ($(VENDOR),1)
-	if ! ischroot; then make vendor; fi
-endif
+	ischroot || env VENDOR=1 make vendor
 
 override_dh_auto_build:
-	env CARGO_HOME="$$(pwd)/target/cargo" make prefix=/usr
-
-override_dh_installinit:
-	dh_installinit -r
-
-override_dh_systemd_start:
-	dh_systemd_start -r
+	env VENDOR=1 make prefix=/usr


### PR DESCRIPTION
Testing a fix for upgrade conflicts that require running `dpkg-configure -a` after upgrade.