### PR TITLE
fix: Improve handling of root-on-ZFS installs during upgrade

### DIFF
--- a/daemon/src/repair/fstab.rs
+++ b/daemon/src/repair/fstab.rs
@@ -13,7 +13,7 @@ pub enum FstabError {
 
 /// Performs the following Pop-specific actions:
 ///
-/// - Ensures that `/boot/efi` and `/recovery` are mounted by PartUUID.
+/// - Ensures that `/boot/efi` and `/` are mounted.
 pub fn repair() -> Result<(), FstabError> {
     if SystemEnvironment::detect() != SystemEnvironment::Efi {
         return Ok(());
@@ -25,7 +25,15 @@ pub fn repair() -> Result<(), FstabError> {
 
 /// Ensure that the necessary mount points are mounted.
 fn mount_required_partitions() -> anyhow::Result<()> {
+    // Check /proc/mounts for existing mountpoints rather than relying entirely
+    // on mount(1), which gets confused by ZFS filesystems (which might be
+    // managed by e.g. zfs-mount.service).
+    let mounts = proc_mounts::MountList::new().context("failed to read /proc/mounts")?;
+
     for mount_point in &["/", "/boot/efi"] {
+        if let Some(_) = mounts.get_mount_by_dest(mount_point) {
+            continue; // Already mounted.
+        }
         Command::new("mount")
             .arg(mount_point)
             .status()


### PR DESCRIPTION
Previously we would error if the root partition was not in `/etc/fstab`, which is the case for ZFS mountpoints managed by e.g. `zfs-mount.service`.

This commit also fixes a related docstring error.

Closes #363.