### PR TITLE
fix: Remove debhelper systemd functions from postinst

### DIFF
--- a/debian/pop-upgrade.postinst
+++ b/debian/pop-upgrade.postinst
@@ -9,6 +9,4 @@ if ! test -e /var/lib/pop-upgrade/restarting && ! test -e /pop-upgrade && ! test
     fi
 fi
 
-#DEBHELPER#
-
 exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@ export VENDOR ?= 1
 CLEAN ?= 1
 
 %:
-	dh $@ --with=systemd
+	dh $@ --without=systemd
 
 override_dh_auto_clean:
 ifeq ($(CLEAN),1)


### PR DESCRIPTION
In my testing, this fixes the dpkg breakage that results in having to run `dpkg --configure -a` after pop-upgrade self-updates.

The auto-generated portion expanded out to this:

```
# Automatically added by dh_systemd_enable/13.14.1ubuntu5
if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
	# The following line should be removed in trixie or trixie+1
	deb-systemd-helper unmask 'pop-upgrade.service' >/dev/null || true

	# was-enabled defaults to true, so new installations run enable.
	if deb-systemd-helper --quiet was-enabled 'pop-upgrade.service'; then
		# Enables the unit on first installation, creates new
		# symlinks on upgrades if the unit file has changed.
		deb-systemd-helper enable 'pop-upgrade.service' >/dev/null || true
	else
		# Update the statefile to add new symlinks (if any), which need to be
		# cleaned up on purge. Also remove old symlinks.
		deb-systemd-helper update-state 'pop-upgrade.service' >/dev/null || true
	fi
fi
# End automatically added section
# Automatically added by dh_systemd_start/13.14.1ubuntu5
if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
	if [ -d /run/systemd/system ]; then
		systemctl --system daemon-reload >/dev/null || true
		if [ -n "$2" ]; then
			_dh_action=restart
		else
			_dh_action=start
		fi
		deb-systemd-invoke $_dh_action 'pop-upgrade-init.service' 'pop-upgrade.service' >/dev/null || true
	fi
fi
# End automatically added section
```

Need to ensure removing this doesn't cause any other problems. I'm a little confused about the targeted state of the pop-upgrade service based on the manual disable & restart we have in this file combined with the debhelper portion.