### PR TITLE
style: fix and enforce formatting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: chore
+      include: scope
+    ignore:
+      - dependency-name: dtolnay/rust-toolchain

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+name: Continuous integration
+
+jobs:
+
+  fmt:
+    name: format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo +nightly fmt --all --check

--- a/daemon/src/cli/mod.rs
+++ b/daemon/src/cli/mod.rs
@@ -43,9 +43,7 @@ const UPGRADE_RESULT_ERROR: &str = "release upgrade aborted";
 pub struct Client(client::Client);
 
 impl Client {
-    pub fn new() -> Result<Self, client::Error> {
-        client::Client::new().map(Client)
-    }
+    pub fn new() -> Result<Self, client::Error> { client::Client::new().map(Client) }
 
     /// Executes the recovery subcommand of the client.
     pub fn recovery(&self, matches: &ArgMatches) -> anyhow::Result<()> {

--- a/daemon/src/daemon/mod.rs
+++ b/daemon/src/daemon/mod.rs
@@ -85,10 +85,18 @@ pub const INSTALL_DATE: &str = "/usr/lib/pop-upgrade/install_date";
 
 #[derive(Debug)]
 pub enum Event {
-    FetchUpdates { apt_uris: HashSet<AptRequest>, download_only: bool },
+    FetchUpdates {
+        apt_uris:      HashSet<AptRequest>,
+        download_only: bool,
+    },
     PackageUpgrade,
     RecoveryUpgrade(RecoveryUpgradeMethod),
-    ReleaseUpgrade { how: ReleaseUpgradeMethod, from: String, to: String, await_recovery: bool },
+    ReleaseUpgrade {
+        how:            ReleaseUpgradeMethod,
+        from:           String,
+        to:             String,
+        await_recovery: bool,
+    },
 }
 
 #[derive(Debug)]
@@ -97,39 +105,37 @@ pub enum FgEvent {
 }
 
 pub struct LastKnown {
-    development: bool,
-    fetch: Result<(), ReleaseError>,
+    development:      bool,
+    fetch:            Result<(), ReleaseError>,
     recovery_upgrade: Result<(), RecoveryError>,
-    release_upgrade: Result<(), ReleaseError>,
+    release_upgrade:  Result<(), ReleaseError>,
 }
 
 impl Default for LastKnown {
     fn default() -> Self {
         Self {
-            development: false,
-            fetch: Ok(()),
+            development:      false,
+            fetch:            Ok(()),
             recovery_upgrade: Ok(()),
-            release_upgrade: Ok(()),
+            release_upgrade:  Ok(()),
         }
     }
 }
 
 pub struct ReleaseUpgradeState {
     action: release::UpgradeMethod,
-    from: Box<str>,
-    to: Box<str>,
+    from:   Box<str>,
+    to:     Box<str>,
 }
 
 #[derive(Clone, Copy, Debug)]
 struct FetchState {
     progress: u64,
-    total: u64,
+    total:    u64,
 }
 
 impl FetchState {
-    pub const fn new(progress: u64, total: u64) -> Self {
-        Self { progress, total }
-    }
+    pub const fn new(progress: u64, total: u64) -> Self { Self { progress, total } }
 }
 
 unsafe impl bytemuck::NoUninit for FetchState {}
@@ -137,15 +143,15 @@ unsafe impl bytemuck::NoUninit for FetchState {}
 struct SharedState {
     // In case a UI is being constructed after a task has already started, it may request
     // for the curernt progress of a task.
-    fetching_state: Atomic<FetchState>,
+    fetching_state:        Atomic<FetchState>,
     // The status of the event loop thread, which indicates the current task, or lack thereof.
-    status: Atomic<DaemonStatus>,
+    status:                Atomic<DaemonStatus>,
     // As well as the current sub-status, if relevant.
-    sub_status: AtomicU8,
+    sub_status:            AtomicU8,
     // Cancels a process that is currently active.
-    shutdown: Mutex<Shutdown<()>>,
+    shutdown:              Mutex<Shutdown<()>>,
     // Development release
-    force_next: AtomicBool,
+    force_next:            AtomicBool,
     // Indicates that it is now uncancellable
     release_upgrade_began: AtomicBool,
 }
@@ -157,12 +163,12 @@ enum ReleaseCheck {
 }
 
 pub struct Daemon {
-    event_tx: UnboundedSender<Event>,
-    last_known: LastKnown,
+    event_tx:        UnboundedSender<Event>,
+    last_known:      LastKnown,
     perform_upgrade: bool,
-    release_check: ReleaseCheck,
+    release_check:   ReleaseCheck,
     release_upgrade: Option<ReleaseUpgradeState>,
-    shared_state: Arc<SharedState>,
+    shared_state:    Arc<SharedState>,
 }
 
 impl Daemon {
@@ -180,11 +186,11 @@ impl Daemon {
 
         // State shared between the background task thread, and the foreground DBus event loop.
         let shared_state = Arc::new(SharedState {
-            status: Atomic::new(DaemonStatus::Inactive),
-            sub_status: AtomicU8::new(0),
-            fetching_state: Atomic::new(FetchState::new(0, 0)),
-            shutdown: Mutex::new(Shutdown::new()),
-            force_next: AtomicBool::new(false),
+            status:                Atomic::new(DaemonStatus::Inactive),
+            sub_status:            AtomicU8::new(0),
+            fetching_state:        Atomic::new(FetchState::new(0, 0)),
+            shutdown:              Mutex::new(Shutdown::new()),
+            force_next:            AtomicBool::new(false),
             release_upgrade_began: AtomicBool::new(false),
         });
 
@@ -1023,8 +1029,8 @@ impl Daemon {
 
         let event = Event::RecoveryUpgrade(RecoveryUpgradeMethod::FromRelease {
             version: if version.is_empty() { None } else { Some(version.into()) },
-            arch: if arch.is_empty() { None } else { Some(arch.into()) },
-            flags: RecoveryReleaseFlags::from_bits_truncate(flags),
+            arch:    if arch.is_empty() { None } else { Some(arch.into()) },
+            flags:   RecoveryReleaseFlags::from_bits_truncate(flags),
         });
 
         self.submit_event(event)

--- a/daemon/src/fetch/apt.rs
+++ b/daemon/src/fetch/apt.rs
@@ -44,8 +44,13 @@ pub async fn fetch_uris(
                 .noninteractive()
                 .fetch_uris(&args)
                 .await
-                .context("failed to exec `apt-get install --print-uris` or `apt-get download --print-uris`")?
-                .context("failed to fetch package URIs from `apt-get install` or `apt-get download`")?;
+                .context(
+                    "failed to exec `apt-get install --print-uris` or `apt-get download \
+                     --print-uris`",
+                )?
+                .context(
+                    "failed to fetch package URIs from `apt-get install` or `apt-get download`",
+                )?;
 
             for uri in install_uris {
                 uris.insert(uri);

--- a/daemon/src/release/repos.rs
+++ b/daemon/src/release/repos.rs
@@ -438,9 +438,7 @@ pub fn iter_files(dir: ReadDir) -> impl Iterator<Item = DirEntry> {
     dir.filter_map(Result::ok).filter(|entry| entry.metadata().ok().map_or(false, |m| m.is_file()))
 }
 
-fn is_save_file(path: &Path) -> bool {
-    path.extension() == Some(OsStr::from_bytes(b"save"))
-}
+fn is_save_file(path: &Path) -> bool { path.extension() == Some(OsStr::from_bytes(b"save")) }
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
applies the (already configured) rust formatting, as specified in the `CONTRIBUTING.md` guide

also adds a github workflow to check the formatting on PRs, and a dependabot config to keep the CI job up-to-date