### PR TITLE
fix: update usage of deprecated chrono APIs

### DIFF
--- a/daemon/src/cli/mod.rs
+++ b/daemon/src/cli/mod.rs
@@ -4,7 +4,7 @@ mod prompt;
 use self::colors::*;
 use crate::notify::notify;
 use apt_cmd::AptUpgradeEvent;
-use chrono::{TimeZone, Utc};
+use chrono::NaiveDate;
 use clap::ArgMatches;
 use num_traits::FromPrimitive;
 use pop_upgrade::{
@@ -576,7 +576,9 @@ fn notification_message(current: &str, next: &str) -> (String, String) {
                 return (
                     fomat!(
                         "Support for Pop!_OS " (current) " ends "
-                        (Utc.ymd(y as i32, m, d).format("%B %-d, %Y"))
+                        (NaiveDate::from_ymd_opt(y as i32, m, d)
+                            .expect("invalid EOL date")
+                            .format("%B %-d, %Y"))
                     ),
                     fomat!(
                         "This computer will soon stop receiving updates"

--- a/daemon/src/ubuntu_version/version.rs
+++ b/daemon/src/ubuntu_version/version.rs
@@ -48,7 +48,7 @@ impl Version {
 
     /// The number of months that have passed since this version was released.
     pub fn months_since(self) -> i32 {
-        let today = Utc::today();
+        let today = Utc::now().date_naive();
 
         let major = 2000 - today.year() as u32;
         let minor = today.month() as u32;

--- a/gtk/src/events/mod.rs
+++ b/gtk/src/events/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     RECOVERY_PARTITION, REFRESH_OS,
 };
 
-use chrono::{TimeZone, Utc};
+use chrono::NaiveDate;
 use gtk::prelude::*;
 
 use pop_upgrade::{
@@ -327,7 +327,11 @@ fn connect_upgrade(state: &mut State, widgets: &EventWidgets, is_lts: bool, rebo
                 EolStatus::Imminent => Some(fl!(
                     "eol-imminent",
                     current = fomat!((eol.version)),
-                    date = fomat!((Utc.ymd(y as i32, m, d).format("%B %-d, %Y")))
+                    date = fomat!((
+                        NaiveDate::from_ymd_opt(y as i32, m, d)
+                            .expect("invalid EOL date")
+                            .format("%B %-d, %Y")
+                    ))
                 )),
                 EolStatus::Ok => None,
             }


### PR DESCRIPTION
`chrono::Date` and associated APIs are deprecated and will be removed in a future version.

PR updates all usages to `NaiveDate`