### PR TITLE
fix: add max retry limit to network_reconnect to prevent infinite loop

### DIFF
--- a/daemon/src/misc.rs
+++ b/daemon/src/misc.rs
@@ -90,6 +90,9 @@ where
     Fun: Fn() -> Fut,
     Fut: Future<Output = Res>,
 {
+    const MAX_RETRIES: u32 = 10;
+    let mut retries = 0;
+
     loop {
         let request = func();
         let changed = async_fetcher::iface::watch_change();
@@ -101,7 +104,22 @@ where
 
         match futures::future::select(request, changed).await {
             Either::Left((result, _)) => break result,
-            Either::Right(_) => tokio::time::sleep(Duration::from_secs(3)).await,
+            Either::Right(_) => {
+                retries += 1;
+                if retries >= MAX_RETRIES {
+                    warn!(
+                        "network_reconnect: max retries ({}) reached, proceeding with final \
+                         attempt",
+                        MAX_RETRIES
+                    );
+                    break func().await;
+                }
+                warn!(
+                    "network_reconnect: network change detected, retry {}/{}",
+                    retries, MAX_RETRIES
+                );
+                tokio::time::sleep(Duration::from_secs(3)).await;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Add a max retry limit to `network_reconnect()` to prevent an infinite loop that pins a CPU core at 100%.

Fixes #297
Fixes #131

## Problem

`network_reconnect()` in `daemon/src/misc.rs` races an HTTP request against `async_fetcher::iface::watch_change()`. If the network interface watcher fires before the HTTP request completes, it sleeps 3 seconds and retries — **forever**, with no exit condition.

When the network is flaky (suspend/resume, captive portal, DNS failure, interface flapping), the watcher fires rapidly and the daemon burns a full CPU core indefinitely. This has been reported by multiple users over 3+ years in #297.

## Fix

- Add `MAX_RETRIES = 10` — after 10 network-change interruptions, proceed with one final request attempt
- Log a warning on each retry for diagnostics
- **No behavior change for the happy path** — if the request completes before a network change, it returns immediately as before