### PR TITLE
Fix: Remove Infinite Retry on Metadata Fetch To Prevent 100% CPU Usage

### DIFF
--- a/daemon/src/misc.rs
+++ b/daemon/src/misc.rs
@@ -83,4 +83,3 @@ pub fn uid_min_max() -> anyhow::Result<(u32, u32)> {
             Ok((min, max))
         })
 }
-

--- a/daemon/src/misc.rs
+++ b/daemon/src/misc.rs
@@ -1,12 +1,11 @@
 use anyhow::Context;
-use std::{fs, future::Future, io, path::Path, time::Duration};
+use std::{fs, io, path::Path, time::Duration};
 use tokio::fs::{copy, File};
 
 pub fn http_client() -> Result<reqwest::Client, reqwest::Error> {
     reqwest::ClientBuilder::new()
-        // Error if the HTTP header response, or the time to fetch a chunk of a body, exceeds 30 seconds.
+        .connect_timeout(Duration::from_secs(30))
         .read_timeout(Duration::from_secs(30))
-        // Limit to following 10 redirects before failing.
         .redirect(reqwest::redirect::Policy::limited(10))
         .build()
 }
@@ -85,23 +84,3 @@ pub fn uid_min_max() -> anyhow::Result<(u32, u32)> {
         })
 }
 
-pub async fn network_reconnect<Fun, Fut, Res>(func: Fun) -> Res
-where
-    Fun: Fn() -> Fut,
-    Fut: Future<Output = Res>,
-{
-    loop {
-        let request = func();
-        let changed = async_fetcher::iface::watch_change();
-
-        futures::pin_mut!(request);
-        futures::pin_mut!(changed);
-
-        use futures::future::Either;
-
-        match futures::future::select(request, changed).await {
-            Either::Left((result, _)) => break result,
-            Either::Right(_) => tokio::time::sleep(Duration::from_secs(3)).await,
-        }
-    }
-}

--- a/daemon/src/release/repos.rs
+++ b/daemon/src/release/repos.rs
@@ -152,8 +152,7 @@ pub async fn is_old_release(codename: &str) -> bool {
     let url = &["http://old-releases.ubuntu.com/ubuntu/dists/", codename, "/Release"].concat();
 
     if let Ok(client) = crate::misc::http_client() {
-        let request = || async { client.head(url).send().await };
-        if let Ok(resp) = crate::misc::network_reconnect(request).await {
+        if let Ok(resp) = client.head(url).send().await {
             return resp.status().is_success();
         }
     }

--- a/daemon/src/release_api.rs
+++ b/daemon/src/release_api.rs
@@ -63,15 +63,12 @@ impl Release {
         info!("checking for build {} in channel {}", version, channel);
         let url = [BASE, "builds/", version, "/", channel].concat();
 
-        let response = crate::misc::network_reconnect(|| async {
-            crate::misc::http_client()
-                .map_err(ApiError::Get)?
-                .get(&url)
-                .send()
-                .await
-                .map_err(ApiError::Get)
-        })
-        .await?;
+        let response = crate::misc::http_client()
+            .map_err(ApiError::Get)?
+            .get(&url)
+            .send()
+            .await
+            .map_err(ApiError::Get)?;
 
         let status = response.status();
         if !status.is_success() {


### PR DESCRIPTION
This PR attempts to remove an infinite loop caused by a race between the network interface watcher and a network request. I suspect that this race is the root-cause behind [100% CPU issue](https://github.com/pop-os/upgrade/issues/297).

Errors that occur during the metadata fetch will simply be propagated up and handled.