### PR TITLE
Prevent busy-spin on dbus connection error in main event loop - Possibly addresses #297

### DIFF
--- a/daemon/src/daemon/mod.rs
+++ b/daemon/src/daemon/mod.rs
@@ -797,7 +797,11 @@ impl Daemon {
         let mut shutdown_triggered = false;
 
         loop {
-            let _ = connection.process(std::time::Duration::from_millis(500));
+            if connection.process(std::time::Duration::from_millis(500)).is_err() {
+                warn!("dbus connection error, retrying in 5s");
+                std::thread::sleep(std::time::Duration::from_secs(5));
+                continue;
+            }
             let mut lock = cr.lock().unwrap();
             let daemon: &mut Daemon = lock.data_mut(&path).unwrap();
 

--- a/daemon/src/daemon/mod.rs
+++ b/daemon/src/daemon/mod.rs
@@ -799,7 +799,7 @@ impl Daemon {
         loop {
             if connection.process(std::time::Duration::from_millis(500)).is_err() {
                 warn!("dbus connection error, retrying in 5s");
-                std::thread::sleep(std::time::Duration::from_secs(5));
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 continue;
             }
             let mut lock = cr.lock().unwrap();


### PR DESCRIPTION
Fix the busy-spin loop when connection.process() returns an error.